### PR TITLE
Updates charts to be more usable.

### DIFF
--- a/app/src/main/java/com/pulseloop/ui/PulseLoopApp.kt
+++ b/app/src/main/java/com/pulseloop/ui/PulseLoopApp.kt
@@ -1,13 +1,17 @@
 package com.pulseloop.ui
 
+import android.content.res.Configuration
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material.icons.outlined.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
@@ -151,32 +155,63 @@ fun PulseLoopApp() {
             Tab("coach", "Coach", Icons.Filled.AutoAwesome, Icons.Outlined.AutoAwesome),
         )
 
+        val isLandscape =
+            LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE
         Scaffold(
             bottomBar = {
-                NavigationBar {
-                    val navBackStackEntry by navController.currentBackStackEntryAsState()
-                    val currentDestination = navBackStackEntry?.destination
-                    tabs.forEach { tab ->
-                        val selected = currentDestination?.hierarchy?.any { it.route == tab.route } == true
-                        NavigationBarItem(
-                            icon = {
-                                Icon(
-                                    if (selected) tab.selectedIcon else tab.unselectedIcon,
-                                    contentDescription = tab.label,
-                                )
-                            },
-                            label = { Text(tab.label) },
-                            selected = selected,
-                            onClick = {
-                                if (selected) return@NavigationBarItem
-                                // Pop everything above the start destination but keep it.
-                                // launchSingleTop jumps back to the existing tab instance.
-                                navController.navigate(tab.route) {
-                                    popUpTo(navController.graph.startDestinationId)
-                                    launchSingleTop = true
+                val navBackStackEntry by navController.currentBackStackEntryAsState()
+                val currentDestination = navBackStackEntry?.destination
+                fun isSelected(tab: Tab) =
+                    currentDestination?.hierarchy?.any { it.route == tab.route } == true
+                val onTab: (Tab) -> Unit = { tab ->
+                    // Pop everything above the start destination but keep it;
+                    // launchSingleTop jumps back to the existing tab instance.
+                    if (!isSelected(tab)) navController.navigate(tab.route) {
+                        popUpTo(navController.graph.startDestinationId)
+                        launchSingleTop = true
+                    }
+                }
+                if (isLandscape) {
+                    // Landscape: a compact icon-only bar at ~half the standard height,
+                    // so the short viewport keeps more room for content.
+                    Surface(color = NavigationBarDefaults.containerColor) {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .windowInsetsPadding(NavigationBarDefaults.windowInsets)
+                                .height(48.dp),
+                            horizontalArrangement = Arrangement.SpaceEvenly,
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            tabs.forEach { tab ->
+                                val selected = isSelected(tab)
+                                IconButton(onClick = { onTab(tab) }) {
+                                    Icon(
+                                        if (selected) tab.selectedIcon else tab.unselectedIcon,
+                                        contentDescription = tab.label,
+                                        tint = if (selected) MaterialTheme.colorScheme.primary
+                                        else MaterialTheme.colorScheme.onSurfaceVariant,
+                                    )
                                 }
-                            },
-                        )
+                            }
+                        }
+                    }
+                } else {
+                    NavigationBar {
+                        tabs.forEach { tab ->
+                            val selected = isSelected(tab)
+                            NavigationBarItem(
+                                icon = {
+                                    Icon(
+                                        if (selected) tab.selectedIcon else tab.unselectedIcon,
+                                        contentDescription = tab.label,
+                                    )
+                                },
+                                label = { Text(tab.label) },
+                                selected = selected,
+                                onClick = { onTab(tab) },
+                            )
+                        }
                     }
                 }
             },

--- a/app/src/main/java/com/pulseloop/ui/components/Charts.kt
+++ b/app/src/main/java/com/pulseloop/ui/components/Charts.kt
@@ -50,6 +50,14 @@ import java.time.temporal.ChronoUnit
 import java.util.Locale
 import kotlin.math.abs
 import kotlin.math.roundToInt
+import kotlinx.coroutines.withTimeoutOrNull
+
+/**
+ * Delay before a touch that starts on the chart is claimed for scrub/zoom. Within this
+ * window a drag that passes touch-slop is treated as a parent-list scroll instead, so the
+ * chart can sit inside a scrollable column without trapping vertical swipes.
+ */
+private const val CHART_TOUCH_DELAY_MS = 160L
 
 /**
  * Builds hard-edged vertical-gradient color stops from a metric's threshold zones,
@@ -445,6 +453,21 @@ fun TrendChart(
             if (!interactive) base else base.pointerInput(points) {
                 awaitEachGesture {
                     val first = awaitFirstDown(requireUnconsumed = false)
+                    // Disambiguate scroll vs. scrub: wait briefly before claiming the gesture.
+                    // A second finger claims immediately (zoom); a drag past touch-slop or a
+                    // quick lift yields to the parent list; staying put past the delay scrubs.
+                    val slop = viewConfiguration.touchSlop
+                    var claimed = false
+                    withTimeoutOrNull(CHART_TOUCH_DELAY_MS) {
+                        while (true) {
+                            val ev = awaitPointerEvent()
+                            if (ev.changes.count { it.pressed } >= 2) { claimed = true; return@withTimeoutOrNull }
+                            val ch = ev.changes.firstOrNull { it.id == first.id }
+                            if (ch == null || !ch.pressed) return@withTimeoutOrNull
+                            if ((ch.position - first.position).getDistanceSquared() > slop * slop) return@withTimeoutOrNull
+                        }
+                    } ?: run { claimed = true }   // timed out with the finger held still → scrub
+                    if (!claimed) return@awaitEachGesture
                     scrubX = first.position.x
                     var multiTouch = false
                     while (true) {

--- a/app/src/main/java/com/pulseloop/ui/components/Charts.kt
+++ b/app/src/main/java/com/pulseloop/ui/components/Charts.kt
@@ -2,13 +2,21 @@ package com.pulseloop.ui.components
 
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.calculateCentroid
+import androidx.compose.foundation.gestures.calculatePan
+import androidx.compose.foundation.gestures.calculateZoom
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -22,12 +30,21 @@ import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.drawscope.clipRect
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.drawText
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
+import java.util.Locale
+import kotlin.math.abs
+import kotlin.math.roundToInt
 
 /**
  * Builds hard-edged vertical-gradient color stops from a metric's threshold zones,
@@ -307,14 +324,49 @@ private fun formatTick(value: Double): String {
     else "%.1f".format(value)
 }
 
+/**
+ * Clean clock-time ticks for the X axis across the visible window [visStart, visEnd].
+ * Picks a step (15 min … 7 days) that yields ~5 labels, aligns ticks to local
+ * midnight, and returns a label formatter whose granularity matches the step
+ * (e.g. "2 PM" for hourly, "2:30 PM" sub-hour, "Jun 28" for multi-day).
+ */
+private fun timeAxisTicks(visStart: Long, visEnd: Long, zone: ZoneId): Pair<List<Long>, (Long) -> String> {
+    val rangeMs = (visEnd - visStart).coerceAtLeast(1L)
+    val stepsMin = longArrayOf(15, 30, 60, 120, 180, 360, 720, 1440, 2880, 10080)
+    val stepMin = stepsMin.firstOrNull { rangeMs / (it * 60_000L) <= 5 } ?: stepsMin.last()
+    val stepMs = stepMin * 60_000L
+    val pattern = when {
+        stepMin >= 1440 -> "MMM d"
+        stepMin < 60 -> "h:mm a"
+        else -> "h a"
+    }
+    val fmt = DateTimeFormatter.ofPattern(pattern, Locale.getDefault())
+    // Align ticks to local midnight so labels land on clean boundaries.
+    val dayStart = Instant.ofEpochMilli(visStart).atZone(zone)
+        .truncatedTo(ChronoUnit.DAYS).toInstant().toEpochMilli()
+    val ticks = mutableListOf<Long>()
+    var t = dayStart
+    while (t < visStart) t += stepMs
+    while (t <= visEnd) { ticks.add(t); t += stepMs }
+    val formatter: (Long) -> String = { ms -> Instant.ofEpochMilli(ms).atZone(zone).format(fmt) }
+    return ticks to formatter
+}
+
 // ──────────────────────── TrendChart ────────────────────────
 
 /**
- * Enhanced line chart for the Vital Detail screen — adds gradient fill under the line,
- * gridlines, x-axis labels, and value-axis min/max annotations.
+ * Enhanced line chart for the Vital Detail screen — gradient fill under the line,
+ * gridlines, value (Y) axis labels, aligned time (X) axis labels, and touch interaction:
+ *   • single-finger drag → scrub: a guide line + tooltip showing the value and time
+ *     at the touched point;
+ *   • two-finger pinch / pan → zoom into and pan across the time domain.
  *
  * For BP, use [secondary] to overlay a second series with [colorSecondary] and show
  * [legendPrimary]/[legendSecondary] labels.
+ *
+ * @param timestamps optional epoch-ms per point (parallel to [points]); when present the
+ *   scrub tooltip shows a precise time via [tooltipTimeFormatter].
+ * @param valueFormatter formats Y-axis + tooltip values (default: integer / 1-dp).
  */
 @Composable
 fun TrendChart(
@@ -327,6 +379,10 @@ fun TrendChart(
     legendPrimary: String? = null,
     legendSecondary: String? = null,
     thresholds: MetricThresholds? = null,
+    timestamps: List<Long> = emptyList(),
+    valueFormatter: (Double) -> String = ::formatTick,
+    tooltipTimeFormatter: ((Long) -> String)? = null,
+    interactive: Boolean = true,
 ) {
     if (points.isEmpty()) return
 
@@ -336,6 +392,37 @@ fun TrendChart(
     val range = if (max == min) 1.0 else max - min
     // Zone-color the primary line only for single-series metrics (not BP's dual lines).
     val zoneColoring = thresholds != null && secondary.isEmpty()
+    val n = points.size
+
+    // Time domain: when we have a timestamp per point, plot on a real time axis so the
+    // x positions and labels reflect actual clock time (not even index spacing). The full
+    // domain is the data's time span (e.g. the last 24h); pinch zooms into it.
+    val useTime = timestamps.size == n && n >= 1
+    val tMin = if (useTime) timestamps.min() else 0L
+    val tMax = if (useTime) timestamps.max() else 0L
+    val tFullStart = if (useTime && tMax > tMin) tMin else tMin - 1_800_000L
+    val tFullEnd = if (useTime && tMax > tMin) tMax else tMax + 1_800_000L
+    val fullRangeMs = (tFullEnd - tFullStart).coerceAtLeast(1L)
+    val zone = ZoneId.systemDefault()
+
+    val textMeasurer = rememberTextMeasurer()
+    val axisColor = MaterialTheme.colorScheme.onSurfaceVariant
+    val surfaceColor = MaterialTheme.colorScheme.surface
+    val onSurfaceColor = MaterialTheme.colorScheme.onSurface
+    val outlineColor = MaterialTheme.colorScheme.outline
+    val gridColor = Color.LightGray.copy(alpha = 0.3f)
+
+    // Zoom/pan window normalized to [0,1] over the time domain. windowSize = 1/zoom.
+    // Min visible window is 30 min; index fallback caps by point count.
+    val minWindowMs = 30 * 60 * 1000L
+    val maxZoom = if (useTime) (fullRangeMs.toFloat() / minWindowMs).coerceIn(1f, 24f)
+        else if (n > 2) minOf(8f, n / 2f) else 1f
+    var zoom by remember(points) { mutableStateOf(1f) }
+    var windowStart by remember(points) { mutableStateOf(0f) }
+    // Scrub touch x in px; null = no tooltip. Plot bounds shared with the gesture handler.
+    var scrubX by remember(points) { mutableStateOf<Float?>(null) }
+    var plotLeftPx by remember { mutableStateOf(0f) }
+    var plotRightPx by remember { mutableStateOf(0f) }
 
     Column(modifier = modifier) {
         // Legend row (for dual-series)
@@ -349,114 +436,256 @@ fun TrendChart(
             }
         }
 
-        Canvas(modifier = Modifier.fillMaxWidth().height(200.dp)) {
-            val w = size.width
-            val h = size.height
-            val pad = 32f
-            val topPad = 12f
-            val bottomPad = 24f
-
-            // Gridlines
-            val gridCount = 4
-            for (i in 0..gridCount) {
-                val y = topPad + (h - topPad - bottomPad) * i / gridCount
-                drawLine(
-                    color = Color.LightGray.copy(alpha = 0.3f),
-                    start = Offset(pad, y),
-                    end = Offset(w - pad, y),
-                    strokeWidth = 1f,
-                )
-            }
-
-            // Value axis annotations (min/max)
-            // (simplified — just show the extremes)
-
-            fun drawSeries(series: List<Double>, seriesColor: Color, zoneColored: Boolean = false) {
-                if (series.isEmpty()) return
-                val stepX = (w - pad * 2) / maxOf(1, series.size - 1)
-                val lineTop = topPad
-                val lineBottom = h - bottomPad
-
-                // Gradient fill under the line (kept single-color for readability)
-                val fillPath = Path()
-                series.forEachIndexed { i, value ->
-                    val x = pad + i * stepX
-                    val y = topPad + (h - topPad - bottomPad) * (1f - ((value - min) / range).toFloat())
-                    if (i == 0) fillPath.moveTo(x, y) else fillPath.lineTo(x, y)
-                }
-                val lastX = pad + (series.size - 1) * stepX
-                fillPath.lineTo(lastX, h - bottomPad)
-                fillPath.lineTo(pad, h - bottomPad)
-                fillPath.close()
-
-                drawPath(
-                    path = fillPath,
-                    brush = Brush.verticalGradient(
-                        colors = listOf(seriesColor.copy(alpha = 0.25f), seriesColor.copy(alpha = 0.02f)),
-                    ),
-                )
-
-                val lineBrush = if (zoneColored && thresholds != null) {
-                    Brush.verticalGradient(
-                        colorStops = zoneGradientStops(min, max, thresholds),
-                        startY = lineTop,
-                        endY = lineBottom,
-                    )
-                } else null
-
-                // The line itself
-                val linePath = Path()
-                series.forEachIndexed { i, value ->
-                    val x = pad + i * stepX
-                    val y = topPad + (h - topPad - bottomPad) * (1f - ((value - min) / range).toFloat())
-                    if (i == 0) linePath.moveTo(x, y) else linePath.lineTo(x, y)
-                    val dotColor = if (zoneColored) thresholds?.zoneFor(value)?.color ?: seriesColor else seriesColor
-                    drawCircle(dotColor, 3f, Offset(x, y))
-                }
-                if (lineBrush != null) {
-                    drawPath(linePath, brush = lineBrush, style = Stroke(width = 2f, cap = StrokeCap.Round))
-                } else {
-                    drawPath(linePath, seriesColor, style = Stroke(width = 2f, cap = StrokeCap.Round))
-                }
-
-                // Current-value marker: larger highlighted dot at the last point
-                if (series.size >= 2) {
-                    val lastIdx = series.lastIndex
-                    val lastX = pad + lastIdx * stepX
-                    val lastY = topPad + (h - topPad - bottomPad) * (1f - ((series[lastIdx] - min) / range).toFloat())
-                    val lastColor = if (zoneColored) thresholds?.zoneFor(series[lastIdx])?.color ?: seriesColor else seriesColor
-                    // White ring
-                    drawCircle(Color.White, 7f, Offset(lastX, lastY))
-                    // Colored inner dot
-                    drawCircle(lastColor, 5f, Offset(lastX, lastY))
+        val canvasModifier = Modifier.fillMaxWidth().height(220.dp).let { base ->
+            if (!interactive) base else base.pointerInput(points) {
+                awaitEachGesture {
+                    val first = awaitFirstDown(requireUnconsumed = false)
+                    scrubX = first.position.x
+                    var multiTouch = false
+                    while (true) {
+                        val event = awaitPointerEvent()
+                        val pressedCount = event.changes.count { it.pressed }
+                        if (pressedCount == 0) break
+                        if (pressedCount >= 2 && maxZoom > 1f) {
+                            // Pinch-zoom + pan, focal-stable around the gesture centroid.
+                            multiTouch = true
+                            scrubX = null
+                            val plotW = (plotRightPx - plotLeftPx).coerceAtLeast(1f)
+                            val oldWindow = 1f / zoom
+                            val focal = ((event.calculateCentroid().x - plotLeftPx) / plotW).coerceIn(0f, 1f)
+                            val focalData = windowStart + focal * oldWindow
+                            val newZoom = (zoom * event.calculateZoom()).coerceIn(1f, maxZoom)
+                            val newWindow = 1f / newZoom
+                            var newStart = focalData - focal * newWindow
+                            newStart -= (event.calculatePan().x / plotW) * newWindow
+                            windowStart = newStart.coerceIn(0f, (1f - newWindow).coerceAtLeast(0f))
+                            zoom = newZoom
+                            event.changes.forEach { it.consume() }
+                        } else if (!multiTouch && pressedCount == 1) {
+                            val change = event.changes.first { it.pressed }
+                            scrubX = change.position.x
+                            change.consume()
+                        }
+                    }
+                    scrubX = null  // hide tooltip when the finger lifts
                 }
             }
-
-            drawSeries(secondary, colorSecondary)
-            drawSeries(points, color, zoneColored = zoneColoring)
         }
 
-        // X-axis labels
-        if (labels.isNotEmpty()) {
-            Row(
-                Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-            ) {
-                // Show a subset of labels to avoid crowding
-                val labelInterval = maxOf(1, labels.size / 5)
-                labels.forEachIndexed { i, label ->
-                    if (i % labelInterval == 0 || i == labels.lastIndex) {
-                        Text(
-                            text = label,
-                            style = MaterialTheme.typography.labelSmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            maxLines = 1,
-                        )
-                    } else {
-                        Spacer(Modifier.width(1.dp))
-                    }
+        Canvas(modifier = canvasModifier) {
+            val gutter = 36.dp.toPx()
+            val rightPad = 10.dp.toPx()
+            val topPad = 10.dp.toPx()
+            val bottomPad = 22.dp.toPx()
+            val w = size.width
+            val h = size.height
+            val plotLeft = gutter
+            val plotRight = w - rightPad
+            val plotTop = topPad
+            val plotBottom = h - bottomPad
+            val plotW = (plotRight - plotLeft).coerceAtLeast(1f)
+            val plotH = (plotBottom - plotTop).coerceAtLeast(1f)
+            plotLeftPx = plotLeft
+            plotRightPx = plotRight
+
+            val windowSize = 1f / zoom
+            val winStart = windowStart.coerceIn(0f, (1f - windowSize).coerceAtLeast(0f))
+
+            // Visible time window (time domain only).
+            val visStart = tFullStart + (winStart.toDouble() * fullRangeMs).toLong()
+            val visEnd = tFullStart + ((winStart + windowSize).toDouble() * fullRangeMs).toLong()
+            val visRangeMs = (visEnd - visStart).coerceAtLeast(1L)
+
+            fun xForTime(t: Long): Float =
+                plotLeft + ((t - visStart).toFloat() / visRangeMs.toFloat()) * plotW
+            fun xForFrac(p: Float): Float = plotLeft + ((p - winStart) / windowSize) * plotW
+            fun xForIndex(i: Int): Float =
+                if (useTime) xForTime(timestamps[i])
+                else xForFrac(if (n <= 1) 0f else i.toFloat() / (n - 1))
+            fun xForSecondary(j: Int): Float =
+                if (useTime && secondary.size == timestamps.size) xForTime(timestamps[j])
+                else xForFrac(if (secondary.size <= 1) 0f else j.toFloat() / (secondary.size - 1))
+            fun yForValue(v: Double): Float =
+                plotTop + plotH * (1f - ((v - min) / range).toFloat())
+            fun indexForX(x: Float): Int {
+                if (!useTime) {
+                    val frac = winStart + ((x - plotLeft) / plotW).coerceIn(0f, 1f) * windowSize
+                    return (frac * (n - 1)).roundToInt().coerceIn(0, n - 1)
+                }
+                val t = visStart + (((x - plotLeft) / plotW).coerceIn(0f, 1f) * visRangeMs).toLong()
+                var best = 0; var bestDist = Long.MAX_VALUE
+                timestamps.forEachIndexed { i, ts ->
+                    val d = abs(ts - t)
+                    if (d < bestDist) { bestDist = d; best = i }
+                }
+                return best
+            }
+
+            val labelStyle = TextStyle(fontSize = 10.sp, color = axisColor)
+
+            // Gridlines + Y-axis value labels (max at top → min at bottom)
+            val gridCount = 4
+            for (g in 0..gridCount) {
+                val y = plotTop + plotH * g / gridCount
+                drawLine(gridColor, Offset(plotLeft, y), Offset(plotRight, y), 1f)
+                val value = max - (max - min) * g / gridCount
+                val tl = textMeasurer.measure(valueFormatter(value), labelStyle)
+                drawText(tl, topLeft = Offset(plotLeft - 6.dp.toPx() - tl.size.width, y - tl.size.height / 2f))
+            }
+
+            // Series — clipped to the plot rect so zoomed-out points don't bleed over the axes.
+            val primaryOffsets = points.mapIndexed { i, v -> Offset(xForIndex(i), yForValue(v)) }
+            val secondaryOffsets = secondary.mapIndexed { i, v -> Offset(xForSecondary(i), yForValue(v)) }
+            clipRect(plotLeft, plotTop, plotRight, plotBottom) {
+                drawTrendSeries(secondaryOffsets, secondary, colorSecondary, false, thresholds, min, max, plotTop, plotBottom)
+                drawTrendSeries(primaryOffsets, points, color, zoneColoring, thresholds, min, max, plotTop, plotBottom)
+                // Current-value marker at the last primary point
+                primaryOffsets.lastOrNull()?.let { o ->
+                    val c = if (zoneColoring) thresholds?.zoneFor(points.last())?.color ?: color else color
+                    drawCircle(Color.White, 7f, o)
+                    drawCircle(c, 5f, o)
                 }
             }
+
+            // X-axis time labels — real clock times at clean intervals across the visible window.
+            if (useTime) {
+                val (ticks, fmt) = timeAxisTicks(visStart, visEnd, zone)
+                var lastRight = -Float.MAX_VALUE
+                for (t in ticks) {
+                    val text = fmt(t)
+                    val tl = textMeasurer.measure(text, labelStyle)
+                    val cx = xForTime(t)
+                    val tx = (cx - tl.size.width / 2f).coerceIn(plotLeft, plotRight - tl.size.width)
+                    if (tx <= lastRight + 6.dp.toPx()) continue  // avoid overlap
+                    lastRight = tx + tl.size.width
+                    drawText(tl, topLeft = Offset(tx, plotBottom + 4.dp.toPx()))
+                }
+            } else {
+                val slotCount = (plotW / 64.dp.toPx()).toInt().coerceIn(2, 6)
+                var lastDrawnIdx = -1
+                for (s in 0..slotCount) {
+                    val frac = s.toFloat() / slotCount
+                    val idx = ((winStart + frac * windowSize) * (n - 1)).roundToInt().coerceIn(0, n - 1)
+                    if (idx == lastDrawnIdx) continue
+                    lastDrawnIdx = idx
+                    val text = labels.getOrNull(idx) ?: continue
+                    if (text.isEmpty()) continue
+                    val tl = textMeasurer.measure(text, labelStyle)
+                    val tx = (xForIndex(idx) - tl.size.width / 2f).coerceIn(plotLeft, plotRight - tl.size.width)
+                    drawText(tl, topLeft = Offset(tx, plotBottom + 4.dp.toPx()))
+                }
+            }
+
+            // Scrub guide line + tooltip
+            val sx = scrubX
+            if (sx != null && n > 0) {
+                val idx = indexForX(sx.coerceIn(plotLeft, plotRight))
+                val px = xForIndex(idx).coerceIn(plotLeft, plotRight)
+                val py = yForValue(points[idx])
+                // Vertical guide
+                drawLine(outlineColor.copy(alpha = 0.6f), Offset(px, plotTop), Offset(px, plotBottom), 1.5f)
+                // Highlighted point(s)
+                drawCircle(Color.White, 7f, Offset(px, py))
+                drawCircle(if (zoneColoring) thresholds?.zoneFor(points[idx])?.color ?: color else color, 5f, Offset(px, py))
+                val secVal = secondary.getOrNull(idx)
+                if (secVal != null) {
+                    val py2 = yForValue(secVal)
+                    drawCircle(Color.White, 6f, Offset(px, py2))
+                    drawCircle(colorSecondary, 4f, Offset(px, py2))
+                }
+
+                // Tooltip text: value (bold) + time (muted)
+                val valueText = if (secVal != null)
+                    "${valueFormatter(points[idx])} / ${valueFormatter(secVal)}"
+                else valueFormatter(points[idx])
+                val timeText = timestamps.getOrNull(idx)?.let { tooltipTimeFormatter?.invoke(it) }
+                    ?: labels.getOrNull(idx) ?: ""
+                val valStyle = TextStyle(fontSize = 13.sp, color = onSurfaceColor, fontWeight = FontWeight.Bold)
+                val timeStyle = TextStyle(fontSize = 10.sp, color = axisColor)
+                val valTl = textMeasurer.measure(valueText, valStyle)
+                val timeTl = if (timeText.isNotEmpty()) textMeasurer.measure(timeText, timeStyle) else null
+                val padPx = 8.dp.toPx()
+                val gap = 2.dp.toPx()
+                val contentW = maxOf(valTl.size.width, timeTl?.size?.width ?: 0).toFloat()
+                val contentH = valTl.size.height + (timeTl?.let { it.size.height + gap } ?: 0f)
+                val boxW = contentW + padPx * 2
+                val boxH = contentH + padPx * 1.2f
+                val boxLeft = (px - boxW / 2f).coerceIn(plotLeft, plotRight - boxW)
+                val boxTop = if (py - boxH - 8.dp.toPx() >= plotTop) py - boxH - 8.dp.toPx() else py + 8.dp.toPx()
+                drawRoundRect(
+                    color = surfaceColor,
+                    topLeft = Offset(boxLeft, boxTop),
+                    size = Size(boxW, boxH),
+                    cornerRadius = CornerRadius(6.dp.toPx(), 6.dp.toPx()),
+                )
+                drawRoundRect(
+                    color = outlineColor.copy(alpha = 0.4f),
+                    topLeft = Offset(boxLeft, boxTop),
+                    size = Size(boxW, boxH),
+                    cornerRadius = CornerRadius(6.dp.toPx(), 6.dp.toPx()),
+                    style = Stroke(width = 1f),
+                )
+                drawText(valTl, topLeft = Offset(boxLeft + padPx, boxTop + padPx * 0.6f))
+                timeTl?.let {
+                    drawText(it, topLeft = Offset(boxLeft + padPx, boxTop + padPx * 0.6f + valTl.size.height + gap))
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Draws one trend series (gradient fill under the line, the line itself, and per-point dots).
+ * Offsets are pre-projected screen coordinates; callers should [clipRect] to the plot bounds.
+ */
+private fun DrawScope.drawTrendSeries(
+    offsets: List<Offset>,
+    values: List<Double>,
+    seriesColor: Color,
+    zoneColored: Boolean,
+    thresholds: MetricThresholds?,
+    dataMin: Double,
+    dataMax: Double,
+    plotTop: Float,
+    plotBottom: Float,
+) {
+    if (offsets.isEmpty()) return
+
+    // Gradient fill under the line
+    val fill = Path()
+    offsets.forEachIndexed { i, o -> if (i == 0) fill.moveTo(o.x, o.y) else fill.lineTo(o.x, o.y) }
+    fill.lineTo(offsets.last().x, plotBottom)
+    fill.lineTo(offsets.first().x, plotBottom)
+    fill.close()
+    drawPath(
+        fill,
+        brush = Brush.verticalGradient(
+            colors = listOf(seriesColor.copy(alpha = 0.25f), seriesColor.copy(alpha = 0.02f)),
+        ),
+    )
+
+    val lineBrush = if (zoneColored && thresholds != null) {
+        Brush.verticalGradient(
+            colorStops = zoneGradientStops(dataMin, dataMax, thresholds),
+            startY = plotTop,
+            endY = plotBottom,
+        )
+    } else null
+
+    val line = Path()
+    offsets.forEachIndexed { i, o -> if (i == 0) line.moveTo(o.x, o.y) else line.lineTo(o.x, o.y) }
+    if (lineBrush != null) {
+        drawPath(line, brush = lineBrush, style = Stroke(width = 2f, cap = StrokeCap.Round))
+    } else {
+        drawPath(line, seriesColor, style = Stroke(width = 2f, cap = StrokeCap.Round))
+    }
+
+    // Per-point dots only when sparse — at high density they merge into a blob and
+    // just obscure the line (e.g. a month of raw samples).
+    if (offsets.size <= 60) {
+        offsets.forEachIndexed { i, o ->
+            val dotColor = if (zoneColored) thresholds?.zoneFor(values[i])?.color ?: seriesColor else seriesColor
+            drawCircle(dotColor, 3f, o)
         }
     }
 }

--- a/app/src/main/java/com/pulseloop/ui/components/Charts.kt
+++ b/app/src/main/java/com/pulseloop/ui/components/Charts.kt
@@ -10,7 +10,12 @@ import androidx.compose.foundation.gestures.calculateZoom
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Slider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -628,6 +633,33 @@ fun TrendChart(
                 drawText(valTl, topLeft = Offset(boxLeft + padPx, boxTop + padPx * 0.6f))
                 timeTl?.let {
                     drawText(it, topLeft = Offset(boxLeft + padPx, boxTop + padPx * 0.6f + valTl.size.height + gap))
+                }
+            }
+        }
+
+        // Scroll slider + zoom-reset — shown only while zoomed in. The slider pans the
+        // visible window across the time domain; reset returns to the full (unzoomed) view.
+        if (interactive && zoom > 1f) {
+            val sliderWindow = 1f / zoom
+            val maxStart = (1f - sliderWindow).coerceAtLeast(0f)
+            if (maxStart > 0f) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Slider(
+                        value = windowStart.coerceIn(0f, maxStart),
+                        onValueChange = { windowStart = it.coerceIn(0f, maxStart) },
+                        valueRange = 0f..maxStart,
+                        modifier = Modifier.weight(1f),
+                    )
+                    IconButton(onClick = { zoom = 1f; windowStart = 0f }) {
+                        Icon(
+                            Icons.Filled.Refresh,
+                            contentDescription = "Reset zoom",
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/pulseloop/ui/components/Charts.kt
+++ b/app/src/main/java/com/pulseloop/ui/components/Charts.kt
@@ -489,9 +489,13 @@ fun TrendChart(
                             windowStart = newStart.coerceIn(0f, (1f - newWindow).coerceAtLeast(0f))
                             zoom = newZoom
                             event.changes.forEach { it.consume() }
-                        } else if (!multiTouch && pressedCount == 1) {
+                        } else if (pressedCount == 1) {
                             val change = event.changes.first { it.pressed }
-                            scrubX = change.position.x
+                            // First single-finger frame right after a pinch: clear the flag and
+                            // skip one frame so the tooltip doesn't jump on release; subsequent
+                            // moves scrub normally, so you can pinch then drag without lifting.
+                            if (multiTouch) multiTouch = false
+                            else scrubX = change.position.x
                             change.consume()
                         }
                     }

--- a/app/src/main/java/com/pulseloop/ui/screens/Screens.kt
+++ b/app/src/main/java/com/pulseloop/ui/screens/Screens.kt
@@ -1107,7 +1107,7 @@ fun VitalDetailScreen(
                     }
                 }
 
-                // 3. Trend chart
+                // 3. Trend chart (pinch to zoom, drag to scrub)
                 item {
                     TrendChart(
                         points = state.points,
@@ -1119,6 +1119,8 @@ fun VitalDetailScreen(
                         legendPrimary = if (state.isBP) "Systolic" else null,
                         legendSecondary = if (state.isBP) "Diastolic" else null,
                         thresholds = state.thresholds,
+                        timestamps = state.timestamps,
+                        tooltipTimeFormatter = { ts -> tooltipTime(ts, state.period) },
                     )
                 }
 
@@ -1299,9 +1301,17 @@ private fun dateLabel(anchor: Long, period: Period): String {
             val end = dt.plusDays(6)
             "${dt.toLocalDate()} – ${end.toLocalDate()}"
         }
-        Period.MONTH -> {
-            "${dt.month.name.take(3)} ${dt.year}"
-        }
+        Period.MONTH -> "${dt.month.name.take(3)} ${dt.year}"
+    }
+}
+
+/** Precise time label for the chart scrub tooltip, formatted per aggregation period. */
+private fun tooltipTime(ts: Long, period: Period): String {
+    val z = java.time.Instant.ofEpochMilli(ts).atZone(java.time.ZoneId.systemDefault())
+    return when (period) {
+        Period.DAY -> "%02d:00".format(z.hour)
+        Period.WEEK -> "${z.dayOfWeek.name.take(3)} ${z.dayOfMonth}"
+        Period.MONTH -> "${z.month.name.take(3)} ${z.dayOfMonth}"
     }
 }
 

--- a/app/src/main/java/com/pulseloop/ui/screens/Screens.kt
+++ b/app/src/main/java/com/pulseloop/ui/screens/Screens.kt
@@ -1309,7 +1309,7 @@ private fun dateLabel(anchor: Long, period: Period): String {
 private fun tooltipTime(ts: Long, period: Period): String {
     val z = java.time.Instant.ofEpochMilli(ts).atZone(java.time.ZoneId.systemDefault())
     return when (period) {
-        Period.DAY -> "%02d:00".format(z.hour)
+        Period.DAY -> z.format(java.time.format.DateTimeFormatter.ofPattern("h:mm a", java.util.Locale.getDefault()))
         Period.WEEK -> "${z.dayOfWeek.name.take(3)} ${z.dayOfMonth}"
         Period.MONTH -> "${z.month.name.take(3)} ${z.dayOfMonth}"
     }

--- a/app/src/main/java/com/pulseloop/ui/viewmodels/ViewModels.kt
+++ b/app/src/main/java/com/pulseloop/ui/viewmodels/ViewModels.kt
@@ -373,10 +373,13 @@ class VitalDetailViewModel(
 
     data class DetailState(
         val period: Period = Period.DAY,
-        val anchor: Long = TimeUtil.startOfTodayLocal(),
+        // For DAY the anchor is the *end* of a rolling 24-hour window (defaults to now);
+        // for WEEK/MONTH it is the start of the period.
+        val anchor: Long = System.currentTimeMillis(),
         val points: List<Double> = emptyList(),
         val secondary: List<Double> = emptyList(),
         val labels: List<String> = emptyList(),
+        val timestamps: List<Long> = emptyList(),
         val latest: Double? = null,
         val min: Double? = null,
         val avg: Double? = null,
@@ -411,7 +414,7 @@ class VitalDetailViewModel(
 
     fun setPeriod(p: Period) {
         val anchor = when (p) {
-            Period.DAY   -> TimeUtil.startOfTodayLocal()
+            Period.DAY   -> System.currentTimeMillis()   // rolling last 24h, ending now
             Period.WEEK  -> TimeUtil.startOfDayLocal(System.currentTimeMillis())
             Period.MONTH -> TimeUtil.startOfDayLocal(System.currentTimeMillis())
         }
@@ -443,10 +446,9 @@ class VitalDetailViewModel(
                 i.plusMonths(1).toInstant().toEpochMilli()
             }
         }
-        // Disallow going past today
         val todayStart = TimeUtil.startOfTodayLocal()
         val maxAnchor = when (st.period) {
-            Period.DAY -> todayStart
+            Period.DAY -> System.currentTimeMillis()  // rolling: end can reach now
             Period.WEEK -> todayStart
             Period.MONTH -> {
                 val i = Instant.ofEpochMilli(todayStart).atZone(ZoneId.systemDefault())
@@ -458,12 +460,13 @@ class VitalDetailViewModel(
         viewModelScope.launch { refresh() }
     }
 
-    /** Whether forward navigation is allowed (disabled at present period). */
+    /** Whether forward navigation is allowed (disabled at the present/latest window). */
     fun canGoForward(): Boolean {
         val st = _state.value
         val todayStart = TimeUtil.startOfTodayLocal()
         return when (st.period) {
-            Period.DAY   -> st.anchor < todayStart
+            // Enabled only if a full 24h step still fits before now (i.e. we're paged back).
+            Period.DAY   -> st.anchor + 86_400_000L <= System.currentTimeMillis()
             Period.WEEK  -> st.anchor < todayStart
             Period.MONTH -> {
                 val i = Instant.ofEpochMilli(todayStart).atZone(ZoneId.systemDefault())
@@ -474,12 +477,18 @@ class VitalDetailViewModel(
 
     private suspend fun refresh() {
         val st = _state.value
-        val anchor = st.anchor
         val period = st.period
-        val tzOffsetMs = ZoneId.systemDefault().rules.getOffset(Instant.now()).totalSeconds * 1000L
+        val now = System.currentTimeMillis()
+        // DAY is a rolling 24h window ending at the anchor; when we're at the latest
+        // (can't page further forward) keep the end pinned to "now" so it truly rolls.
+        val anchor = if (period == Period.DAY && st.anchor + 86_400_000L > now) now else st.anchor
 
+        val windowStart = when (period) {
+            Period.DAY   -> anchor - 86_400_000L   // rolling last 24h
+            else         -> anchor                 // WEEK/MONTH: anchor = window start
+        }
         val windowEnd = when (period) {
-            Period.DAY   -> anchor + 86_400_000L
+            Period.DAY   -> anchor
             Period.WEEK  -> anchor + 7 * 86_400_000L
             Period.MONTH -> {
                 val i = Instant.ofEpochMilli(anchor).atZone(ZoneId.systemDefault())
@@ -487,12 +496,13 @@ class VitalDetailViewModel(
             }
         }
 
-        // Previous window for trend
-        val prevAnchor = when (period) {
-            Period.DAY   -> anchor - 86_400_000L
-            Period.WEEK  -> anchor - 7 * 86_400_000L
+        // Previous equal-length window, immediately before this one, for the trend read.
+        val prevEnd = windowStart
+        val prevStart = when (period) {
+            Period.DAY   -> windowStart - 86_400_000L
+            Period.WEEK  -> windowStart - 7 * 86_400_000L
             Period.MONTH -> {
-                val i = Instant.ofEpochMilli(anchor).atZone(ZoneId.systemDefault())
+                val i = Instant.ofEpochMilli(windowStart).atZone(ZoneId.systemDefault())
                 i.minusMonths(1).toInstant().toEpochMilli()
             }
         }
@@ -500,34 +510,27 @@ class VitalDetailViewModel(
         val dao = db.measurementDao()
 
         if (metric == "bp") {
-            val sysBuckets = if (period == Period.DAY)
-                dao.hourlyAggregates(MeasurementKind.BLOOD_PRESSURE_SYSTOLIC.name, anchor, windowEnd)
-            else
-                dao.dailyAggregates(MeasurementKind.BLOOD_PRESSURE_SYSTOLIC.name, anchor, windowEnd, tzOffsetMs)
-            val diaBuckets = if (period == Period.DAY)
-                dao.hourlyAggregates(MeasurementKind.BLOOD_PRESSURE_DIASTOLIC.name, anchor, windowEnd)
-            else
-                dao.dailyAggregates(MeasurementKind.BLOOD_PRESSURE_DIASTOLIC.name, anchor, windowEnd, tzOffsetMs)
+            // Every reading, at its real timestamp — no averaging.
+            val sysSamples = dao.range(MeasurementKind.BLOOD_PRESSURE_SYSTOLIC.name, windowStart, windowEnd)
+            val diaSamples = dao.range(MeasurementKind.BLOOD_PRESSURE_DIASTOLIC.name, windowStart, windowEnd)
 
-            val points = sysBuckets.map { it.avgValue }
-            val secondary = diaBuckets.map { it.avgValue }
+            val points = sysSamples.map { it.value }
+            val secondary = diaSamples.map { it.value }
+            val times = sysSamples.map { it.timestamp }
             val allValues = points + secondary
-            val labels = buildLabels(sysBuckets.map { it.bucket }, period)
+            val labels = buildLabels(times, period)
 
-            // Trend from previous window
-            val prevSys = if (period == Period.DAY)
-                dao.hourlyAggregates(MeasurementKind.BLOOD_PRESSURE_SYSTOLIC.name, prevAnchor, anchor)
-            else
-                dao.dailyAggregates(MeasurementKind.BLOOD_PRESSURE_SYSTOLIC.name, prevAnchor, anchor, tzOffsetMs)
-            val prevAvg = if (prevSys.isNotEmpty()) prevSys.map { it.avgValue }.average() else null
+            val prevSys = dao.range(MeasurementKind.BLOOD_PRESSURE_SYSTOLIC.name, prevStart, prevEnd)
+            val prevAvg = if (prevSys.isNotEmpty()) prevSys.map { it.value }.average() else null
             val thisAvg = if (points.isNotEmpty()) points.average() else null
             val trend = computeTrend(thisAvg, prevAvg, if (allValues.isNotEmpty()) allValues.max() - allValues.min() else 1.0)
 
             val latestSys = dao.latest(MeasurementKind.BLOOD_PRESSURE_SYSTOLIC.name)
-            val latestDia = dao.latest(MeasurementKind.BLOOD_PRESSURE_DIASTOLIC.name)
 
             _state.update { it.copy(
+                anchor = anchor,
                 points = points, secondary = secondary, labels = labels,
+                timestamps = times,
                 latest = latestSys,
                 min = allValues.minOrNull(), avg = thisAvg, max = allValues.maxOrNull(),
                 trend = trend, loading = false,
@@ -535,55 +538,37 @@ class VitalDetailViewModel(
         } else {
             val kind = primaryKind ?: return
             val kindName = kind.name
-            val buckets = if (period == Period.DAY)
-                dao.hourlyAggregates(kindName, anchor, windowEnd)
-            else
-                dao.dailyAggregates(kindName, anchor, windowEnd, tzOffsetMs)
-
-            val rawPoints = buckets.map { it.avgValue }
             val glucoseOffset = apiKeyStore?.glucoseOffsetMgdl ?: 0.0
 
-            val points = when (kind) {
-                MeasurementKind.BLOOD_SUGAR -> rawPoints.map { it + glucoseOffset }
-                MeasurementKind.TEMPERATURE -> rawPoints.map { UnitConverter.temperature(it, unitSystem) }
-                else -> rawPoints
+            fun convert(v: Double): Double = when (kind) {
+                MeasurementKind.BLOOD_SUGAR -> v + glucoseOffset
+                MeasurementKind.TEMPERATURE -> UnitConverter.temperature(v, unitSystem)
+                else -> v
             }
 
-            val labels = buildLabels(buckets.map { it.bucket }, period)
+            // Every reading, at its real timestamp — no averaging.
+            val samples = dao.range(kindName, windowStart, windowEnd)
+            val times = samples.map { it.timestamp }
+            val points = samples.map { convert(it.value) }
+            val labels = buildLabels(times, period)
 
-            // Trend from previous window
-            val prevBuckets = if (period == Period.DAY)
-                dao.hourlyAggregates(kindName, prevAnchor, anchor)
-            else
-                dao.dailyAggregates(kindName, prevAnchor, anchor, tzOffsetMs)
-            val prevAvg = if (prevBuckets.isNotEmpty()) {
-                val raw = prevBuckets.map { it.avgValue }.average()
-                when (kind) {
-                    MeasurementKind.BLOOD_SUGAR -> raw + glucoseOffset
-                    MeasurementKind.TEMPERATURE -> UnitConverter.temperature(raw, unitSystem)
-                    else -> raw
-                }
-            } else null
+            val prevSamples = dao.range(kindName, prevStart, prevEnd)
+            val prevAvg = if (prevSamples.isNotEmpty()) convert(prevSamples.map { it.value }.average()) else null
             val thisAvg = if (points.isNotEmpty()) points.average() else null
             val range = if (points.isNotEmpty()) points.max() - points.min() else 1.0
             val trend = computeTrend(thisAvg, prevAvg, range)
 
-            val rawLatest = dao.latest(kindName)
-            val latest = when (kind) {
-                MeasurementKind.BLOOD_SUGAR -> rawLatest?.plus(glucoseOffset)
-                MeasurementKind.TEMPERATURE -> rawLatest?.let { UnitConverter.temperature(it, unitSystem) }
-                else -> rawLatest
-            }
+            val latest = dao.latest(kindName)?.let(::convert)
 
-            // Resting HR from the window's raw samples (not the hourly/daily averages,
-            // which would wash out the low at-rest readings).
-            val resting = if (kind == MeasurementKind.HEART_RATE) {
-                val raw = dao.range(kindName, anchor, windowEnd).map { it.value }
-                HeartRateZones.restingHeartRate(raw)
-            } else null
+            // Resting HR from the window's raw samples (low-percentile estimate).
+            val resting = if (kind == MeasurementKind.HEART_RATE)
+                HeartRateZones.restingHeartRate(samples.map { it.value })
+            else null
 
             _state.update { it.copy(
+                anchor = anchor,
                 points = points, secondary = emptyList(), labels = labels,
+                timestamps = times,
                 latest = latest,
                 min = points.minOrNull(), avg = thisAvg, max = points.maxOrNull(),
                 resting = resting,
@@ -596,23 +581,14 @@ class VitalDetailViewModel(
         if (buckets.isEmpty()) return emptyList()
         val zone = ZoneId.systemDefault()
         return when (period) {
-            Period.DAY -> {
-                // Show hours: 00, 06, 12, 18, 23
-                buckets.map { bucket ->
-                    val hour = Instant.ofEpochMilli(bucket).atZone(zone).hour
-                    "%02d".format(hour)
-                }
+            Period.DAY -> buckets.map { bucket ->
+                "%02d".format(Instant.ofEpochMilli(bucket).atZone(zone).hour)
             }
-            Period.WEEK -> {
-                buckets.map { bucket ->
-                    val day = Instant.ofEpochMilli(bucket).atZone(zone).dayOfWeek
-                    day.name.take(3)
-                }
+            Period.WEEK -> buckets.map { bucket ->
+                Instant.ofEpochMilli(bucket).atZone(zone).dayOfWeek.name.take(3)
             }
-            Period.MONTH -> {
-                buckets.map { bucket ->
-                    Instant.ofEpochMilli(bucket).atZone(zone).dayOfMonth.toString()
-                }
+            Period.MONTH -> buckets.map { bucket ->
+                Instant.ofEpochMilli(bucket).atZone(zone).dayOfMonth.toString()
             }
         }
     }


### PR DESCRIPTION
### Vital Detail chart rework

Reworks the Vital Detail screen to show full-resolution data in an interactive chart.

- **Raw samples** — plots every reading at its real timestamp (was hourly/daily averages), so the ring's ~30-min cadence is visible.
- **Today = rolling last 24h**, with ◀▶ arrows to page between days.
- **Interactive chart** — Y-axis value labels, real clock-time X-axis labels, drag-to-scrub tooltip, and pinch-zoom + pan.