### PR TITLE
Jring spot HRV + working workout tracking (start/persist/calories/types)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,9 +17,12 @@
     <!-- Phase 7: Notifications for coach check-ins (Android 13+) -->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
-    <!-- Phase 4+: Foreground service for workout -->
+    <!-- Phase 4+: Foreground service for workout. Type connectedDevice, NOT health:
+         health requires a runtime permission (ACTIVITY_RECOGNITION/BODY_SENSORS) we
+         never request — startForeground then throws and the sticky service crash-loops.
+         connectedDevice's prerequisite is BLUETOOTH_CONNECT, which the ring needs anyway. -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_HEALTH" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" />
 
     <application
         android:allowBackup="false"
@@ -53,7 +56,7 @@
         <!-- Phase 6: Workout foreground service -->
         <service
             android:name=".service.WorkoutForegroundService"
-            android:foregroundServiceType="health"
+            android:foregroundServiceType="connectedDevice"
             android:exported="false" />
     </application>
 </manifest>

--- a/app/src/main/java/com/pulseloop/ring/JringDriver.kt
+++ b/app/src/main/java/com/pulseloop/ring/JringDriver.kt
@@ -30,6 +30,9 @@ object JringCoordinator : WearableCoordinator {
         WearableCapability.BLOOD_SUGAR,      // combined measurement byte[7] (mmol/L ×10)
         WearableCapability.STRESS,           // combined measurement byte[6]
         WearableCapability.FATIGUE,          // combined measurement byte[5]
+        WearableCapability.HRV,              // combined measurement byte[8] — spot only;
+                                             // the jring protocol has no HRV history sync
+                                             // (Colmi 0x39 equivalent doesn't exist)
         WearableCapability.MANUAL_HEART_RATE,
         WearableCapability.MANUAL_SPO2,
         WearableCapability.REALTIME_HEART_RATE,

--- a/app/src/main/java/com/pulseloop/ring/RingBLEClient.kt
+++ b/app/src/main/java/com/pulseloop/ring/RingBLEClient.kt
@@ -167,7 +167,10 @@ class RingBLEClient(private val context: Context) {
             return
         }
         val matchedType = _state.value.discovered.firstOrNull { it.id == id }?.deviceType
-        beginConnect(target, matchedType)
+        // User-initiated connect: direct (autoConnect=false). A first-time autoConnect
+        // waits passively for a low-duty-cycle advertisement match and can hang for
+        // minutes against a never-bonded ring.
+        beginConnect(target, matchedType, autoConnect = false)
     }
 
     fun connectLastKnown() {
@@ -177,7 +180,7 @@ class RingBLEClient(private val context: Context) {
             bluetoothAdapter.getRemoteDevice(lastId)
         } catch (_: Exception) { null }
         if (device != null) {
-            beginConnect(device, lastKnownDeviceType)
+            beginConnect(device, lastKnownDeviceType, autoConnect = true)
         } else {
             startScanning()
         }
@@ -344,7 +347,7 @@ class RingBLEClient(private val context: Context) {
 
     // MARK: Internal
 
-    private fun beginConnect(target: BluetoothDevice, deviceType: RingDeviceType?) {
+    private fun beginConnect(target: BluetoothDevice, deviceType: RingDeviceType?, autoConnect: Boolean) {
         scanner?.stopScan(scanCallback)
         // Close any stale GATT from a previous (now-dead) connection before opening a new
         // one. Reconnect attempts after an idle drop would otherwise leak GATT clients and
@@ -368,12 +371,12 @@ class RingBLEClient(private val context: Context) {
         )
 
         bluetoothGatt = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            // autoConnect=true matches the official app — connects silently
-            // in the background without showing the Bluetooth status bar icon
-            target.connectGatt(context, true, gattCallback, BluetoothDevice.TRANSPORT_LE)
+            // autoConnect=true only for silent background reconnects to a known ring;
+            // user-initiated connects are direct (false) so they complete or fail fast.
+            target.connectGatt(context, autoConnect, gattCallback, BluetoothDevice.TRANSPORT_LE)
         } else {
             @Suppress("DEPRECATION")
-            target.connectGatt(context, true, gattCallback)
+            target.connectGatt(context, autoConnect, gattCallback)
         }
     }
 
@@ -512,8 +515,11 @@ class RingBLEClient(private val context: Context) {
                         // Request a high-priority connection interval, matching the official app
                         // (BluetoothLeService.requestConnectionPriority(1) on connect).
                         gatt.requestConnectionPriority(BluetoothGatt.CONNECTION_PRIORITY_HIGH)
-                        gatt.requestMtu(512)
-                        gatt.discoverServices()
+                        // Only one GATT procedure may be in flight: a discoverServices()
+                        // issued while the MTU exchange is pending is silently dropped
+                        // (observed on Pixel 6 Pro — onServicesDiscovered never fires).
+                        // Discovery is kicked off from onMtuChanged instead.
+                        if (!gatt.requestMtu(512)) gatt.discoverServices()
                     } else {
                         updateState { copy(lastError = "GATT connect failed: $status") }
                         handleDisconnect(gatt)
@@ -732,7 +738,8 @@ class RingBLEClient(private val context: Context) {
         }
 
         override fun onMtuChanged(gatt: BluetoothGatt, mtu: Int, status: Int) {
-            // No-op for Phase 2; MTU negotiation may be added later
+            // MTU exchange done (success or not) — the GATT queue is free, discover now.
+            gatt.discoverServices()
         }
     }
 

--- a/app/src/main/java/com/pulseloop/ring/RingDecoder.kt
+++ b/app/src/main/java/com/pulseloop/ring/RingDecoder.kt
@@ -230,6 +230,7 @@ object RingDecoder {
             val fatigue = bytes[5].toInt() and 0xFF
             val stress = if (bytes.size > 6) bytes[6].toInt() and 0xFF else 0
             val bloodSugarRaw = if (bytes.size > 7) bytes[7].toInt() and 0xFF else 0
+            val hrv = if (bytes.size > 8) bytes[8].toInt() and 0xFF else 0
 
             if (hr > 0) add(RingDecodedEvent.HeartRateSample(bpm = hr, _timestamp = now))
             if (systolic > 0 || diastolic > 0) add(RingDecodedEvent.HistoryMeasurement(
@@ -257,6 +258,9 @@ object RingDecoder {
                 value = (bloodSugarRaw / 10.0) * 18.016,
                 _timestamp = now,
             ))
+            // HRV (byte[8], i8 in onReceiveSensorData) — same HrvSample event the
+            // Colmi driver emits, so persistence/UI handle both families identically.
+            if (hrv > 0) add(RingDecodedEvent.HrvSample(value = hrv, _timestamp = now))
         }
     }
 

--- a/app/src/main/java/com/pulseloop/service/LiveWorkoutManager.kt
+++ b/app/src/main/java/com/pulseloop/service/LiveWorkoutManager.kt
@@ -27,6 +27,7 @@ class LiveWorkoutManager(
         val latestHeartRate: Int? = null,
         val latestSpO2: Int? = null,
         val hrZone: HeartRateZones.Zone = HeartRateZones.Zone.REST,
+        val calories: Double = 0.0,
     )
 
     private val _state = kotlinx.coroutines.flow.MutableStateFlow(WorkoutState())
@@ -38,6 +39,30 @@ class LiveWorkoutManager(
 
     // Foreground service intent for start/stop
     private val serviceIntent = Intent(context, WorkoutForegroundService::class.java)
+
+    companion object {
+        /** An "active" session older than this is a crash leftover, not a workout. */
+        private const val STALE_SESSION_MS = 12 * 60 * 60_000L
+    }
+
+    // ── Calories (Keytel et al. 2005 — kcal/min from HR + weight + age + sex) ──
+    // ponytail: HR-only estimate; overestimates at near-rest HR and ignores
+    // anaerobic load. Upgrade path: MET-based floor per activity type.
+    private var kcalAccum = 0.0
+    private var profileAge = 35
+    private var profileWeightKg = 75.0
+    private var profileMale = true
+
+    private suspend fun loadProfile() {
+        db.userProfileDao().get()?.let { p ->
+            p.age?.let { profileAge = it }
+            p.weightKg?.let { profileWeightKg = it }
+            p.sex?.let { profileMale = !it.startsWith("f", ignoreCase = true) }
+        }
+    }
+
+    private fun kcalPerMinute(hr: Int): Double =
+        keytelKcalPerMinute(hr, profileWeightKg, profileAge, profileMale)
 
     init {
         polling.onPollCompleted = { refreshNotification() }
@@ -53,6 +78,8 @@ class LiveWorkoutManager(
         )
         db.activitySessionDao().upsert(session)
 
+        kcalAccum = 0.0
+        loadProfile()
         coordinator.startWorkoutHeartRate()
         if (useGps) gps.start(session.id, type)
         polling.start(session.id)
@@ -63,12 +90,44 @@ class LiveWorkoutManager(
         return session
     }
 
+    /**
+     * Re-attach to an unfinished session after the Activity/process was recreated
+     * (rotation, memory pressure, crash). The session row survives in Room; the
+     * in-memory state and loops do not. Elapsed time needs no bookkeeping — the
+     * tick derives it from session.startedAt. Sessions too old to plausibly still
+     * be running are marked cancelled instead of resurrected.
+     */
+    suspend fun reattachIfActive() {
+        if (_state.value.isRecording) return
+        val session = db.activitySessionDao().active() ?: return
+        val now = System.currentTimeMillis()
+        if (now - session.startedAt > STALE_SESSION_MS) {
+            db.activitySessionDao().upsert(session.copy(
+                statusRaw = "cancelled", endedAt = session.updatedAt, updatedAt = now,
+            ))
+            return
+        }
+        val paused = session.statusRaw == "paused"
+        kcalAccum = session.calories ?: 0.0  // restore what pause/finish persisted
+        loadProfile()
+        if (!paused) {
+            coordinator.startWorkoutHeartRate()
+            // Permission may have been revoked while we were away — degrade to no-GPS.
+            if (session.useGps) try { gps.start(session.id, session.type) } catch (_: SecurityException) {}
+            polling.start(session.id)
+            startForegroundService(session.type)
+            startTick(session)
+        }
+        _state.value = _state.value.copy(isRecording = true, isPaused = paused, activeSession = session)
+    }
+
     suspend fun pause(session: ActivitySessionEntity) {
         val now = System.currentTimeMillis()
         val updated = session.copy(
             statusRaw = "paused",
             endedAt = now,
             totalPauseSeconds = session.totalPauseSeconds + ((now - session.startedAt) / 1000.0),
+            calories = kcalAccum,
             updatedAt = now,
         )
         db.activitySessionDao().upsert(updated)
@@ -98,6 +157,7 @@ class LiveWorkoutManager(
         db.activitySessionDao().upsert(session.copy(
             statusRaw = "finished", endedAt = now,
             distanceMeters = gps.state.value.totalDistance,
+            calories = kcalAccum,
             updatedAt = now,
         ))
         coordinator.stopWorkoutHeartRate()
@@ -127,12 +187,14 @@ class LiveWorkoutManager(
                 val distance = gps.state.value.totalDistance
                 val hr = coordinator.latestHRValue
                 val zone = hr?.let { HeartRateZones.zoneFor(it) } ?: HeartRateZones.Zone.REST
+                hr?.let { kcalAccum += kcalPerMinute(it) / 60.0 }  // 1s tick
 
                 _state.value = _state.value.copy(
                     elapsedSeconds = elapsed,
                     distanceMeters = distance,
                     latestHeartRate = hr,
                     hrZone = zone,
+                    calories = kcalAccum,
                 )
 
                 if (elapsed % 5 == 0) refreshNotification()
@@ -170,4 +232,13 @@ class LiveWorkoutManager(
     }
 
     fun destroy() { scope.cancel(); tickJob?.cancel() }
+}
+
+/** Keytel et al. 2005: energy expenditure from HR, floor at 0 (formula goes negative near rest). */
+internal fun keytelKcalPerMinute(hr: Int, weightKg: Double, age: Int, male: Boolean): Double {
+    val kjPerMin = if (male)
+        -55.0969 + 0.6309 * hr + 0.1988 * weightKg + 0.2017 * age
+    else
+        -20.4022 + 0.4472 * hr - 0.1263 * weightKg + 0.0740 * age
+    return (kjPerMin / 4.184).coerceAtLeast(0.0)
 }

--- a/app/src/main/java/com/pulseloop/service/LiveWorkoutManager.kt
+++ b/app/src/main/java/com/pulseloop/service/LiveWorkoutManager.kt
@@ -46,9 +46,10 @@ class LiveWorkoutManager(
     }
 
     // ── Calories (Keytel et al. 2005 — kcal/min from HR + weight + age + sex) ──
-    // ponytail: HR-only estimate; overestimates at near-rest HR and ignores
-    // anaerobic load. Upgrade path: MET-based floor per activity type.
+    // Keytel is HR-only, so anaerobic work (Weights) gets a MET-based floor:
+    // between sets HR falls but the body is still working well above rest.
     private var kcalAccum = 0.0
+    private var activeType = "Workout"
     private var profileAge = 35
     private var profileWeightKg = 75.0
     private var profileMale = true
@@ -61,8 +62,10 @@ class LiveWorkoutManager(
         }
     }
 
-    private fun kcalPerMinute(hr: Int): Double =
-        keytelKcalPerMinute(hr, profileWeightKg, profileAge, profileMale)
+    private fun kcalPerMinute(hr: Int): Double = maxOf(
+        keytelKcalPerMinute(hr, profileWeightKg, profileAge, profileMale),
+        metFloorKcalPerMinute(activeType, profileWeightKg),
+    )
 
     init {
         polling.onPollCompleted = { refreshNotification() }
@@ -79,6 +82,7 @@ class LiveWorkoutManager(
         db.activitySessionDao().upsert(session)
 
         kcalAccum = 0.0
+        activeType = type
         loadProfile()
         coordinator.startWorkoutHeartRate()
         if (useGps) gps.start(session.id, type)
@@ -109,6 +113,7 @@ class LiveWorkoutManager(
         }
         val paused = session.statusRaw == "paused"
         kcalAccum = session.calories ?: 0.0  // restore what pause/finish persisted
+        activeType = session.type
         loadProfile()
         if (!paused) {
             coordinator.startWorkoutHeartRate()
@@ -232,6 +237,19 @@ class LiveWorkoutManager(
     }
 
     fun destroy() { scope.cancel(); tickJob?.cancel() }
+}
+
+/**
+ * MET-based kcal/min floor per activity type (Compendium of Physical Activities;
+ * kcal/min = MET × 3.5 × kg / 200). HR-based estimates miss anaerobic load, so
+ * resistance training gets a floor; aerobic types trust HR (floor 0).
+ */
+internal fun metFloorKcalPerMinute(type: String, weightKg: Double): Double {
+    val met = when (type) {
+        "Weights" -> 4.0  // resistance training, moderate effort (Compendium 02052)
+        else -> 0.0
+    }
+    return met * 3.5 * weightKg / 200.0
 }
 
 /** Keytel et al. 2005: energy expenditure from HR, floor at 0 (formula goes negative near rest). */

--- a/app/src/main/java/com/pulseloop/service/RingSyncCoordinator.kt
+++ b/app/src/main/java/com/pulseloop/service/RingSyncCoordinator.kt
@@ -56,6 +56,10 @@ class RingSyncCoordinator(
     /** Latest live SpO2 %, mirrored for UI without a query. */
     var latestSpO2Value: Int? = null
         private set
+    /** Monotonic count of HRV samples seen this session — lets the HRV series
+     *  loop verify a measurement window actually produced a reading. */
+    var hrvSampleCount = 0
+        private set
 
     var workoutHRActive = false
         private set
@@ -300,6 +304,9 @@ class RingSyncCoordinator(
             }
             is PulseEvent.Spo2Result -> {
                 latestSpO2Value = event.value
+            }
+            is PulseEvent.HrvSample -> {
+                hrvSampleCount++
             }
             is PulseEvent.DeviceStateChanged -> {
                 when (event.state) {

--- a/app/src/main/java/com/pulseloop/service/WorkoutForegroundService.kt
+++ b/app/src/main/java/com/pulseloop/service/WorkoutForegroundService.kt
@@ -38,7 +38,16 @@ class WorkoutForegroundService : Service() {
             ACTION_PAUSE -> { status = "paused"; updateNotification() }
             ACTION_RESUME -> { status = "recording"; updateNotification() }
         }
-        startForeground(NOTIFICATION_ID, buildNotification())
+        // Never crash-loop again: if the OS rejects the FGS promotion (permission
+        // regression, background-start restriction), degrade to no-notification
+        // instead of throwing out of onStartCommand on every sticky restart.
+        try {
+            startForeground(NOTIFICATION_ID, buildNotification())
+        } catch (e: Exception) {
+            android.util.Log.e("WorkoutFGS", "startForeground rejected — stopping service", e)
+            stopSelf()
+            return START_NOT_STICKY
+        }
         return START_STICKY
     }
 

--- a/app/src/main/java/com/pulseloop/ui/PulseLoopApp.kt
+++ b/app/src/main/java/com/pulseloop/ui/PulseLoopApp.kt
@@ -242,18 +242,20 @@ fun PulseLoopApp() {
                     )
                 }
                 composable("onboarding") { OnboardingScreen(onComplete = { navController.navigate("pairing") }) }
-                composable("record") {
+                composable("record/{type}") { backStackEntry ->
+                    val workoutType = backStackEntry.arguments?.getString("type") ?: "Workout"
                     val workoutState = liveWorkout.state.collectAsState().value
                     // Start the session on entry — RecordScreen is display-only and no
                     // other code path calls start(); without this the screen is a dead
-                    // dashboard and nothing is recorded. GPS only if already granted:
-                    // requestLocationUpdates throws SecurityException otherwise.
+                    // dashboard and nothing is recorded. GPS only if already granted
+                    // (requestLocationUpdates throws SecurityException otherwise) and
+                    // the type is outdoor — Weights doesn't need a route.
                     LaunchedEffect(Unit) {
                         if (!liveWorkout.state.value.isRecording) {
                             val hasLocation = androidx.core.content.ContextCompat.checkSelfPermission(
                                 context, android.Manifest.permission.ACCESS_FINE_LOCATION
                             ) == android.content.pm.PackageManager.PERMISSION_GRANTED
-                            liveWorkout.start("Workout", useGps = hasLocation)
+                            liveWorkout.start(workoutType, useGps = hasLocation && workoutType != "Weights")
                         }
                     }
                     RecordScreen(

--- a/app/src/main/java/com/pulseloop/ui/PulseLoopApp.kt
+++ b/app/src/main/java/com/pulseloop/ui/PulseLoopApp.kt
@@ -102,6 +102,10 @@ fun PulseLoopApp() {
             coordinator.start()
             summaryCoordinator.start()
 
+            // Workout persistence: pick an unfinished session back up after the
+            // Activity/process was recreated (tab away, rotation, crash).
+            liveWorkout.reattachIfActive()
+
             // Stale-state guard: a persisted "CONNECTED"/"CONNECTING" must not survive a
             // process restart — the live GATT is gone, so the views would otherwise show a
             // false "Connected". Reset until a real connection re-confirms it.
@@ -240,12 +244,25 @@ fun PulseLoopApp() {
                 composable("onboarding") { OnboardingScreen(onComplete = { navController.navigate("pairing") }) }
                 composable("record") {
                     val workoutState = liveWorkout.state.collectAsState().value
+                    // Start the session on entry — RecordScreen is display-only and no
+                    // other code path calls start(); without this the screen is a dead
+                    // dashboard and nothing is recorded. GPS only if already granted:
+                    // requestLocationUpdates throws SecurityException otherwise.
+                    LaunchedEffect(Unit) {
+                        if (!liveWorkout.state.value.isRecording) {
+                            val hasLocation = androidx.core.content.ContextCompat.checkSelfPermission(
+                                context, android.Manifest.permission.ACCESS_FINE_LOCATION
+                            ) == android.content.pm.PackageManager.PERMISSION_GRANTED
+                            liveWorkout.start("Workout", useGps = hasLocation)
+                        }
+                    }
                     RecordScreen(
                         activityName = workoutState.activeSession?.type ?: "Workout",
                         elapsedSeconds = workoutState.elapsedSeconds,
                         distanceMeters = workoutState.distanceMeters,
                         heartRate = workoutState.latestHeartRate,
                         spO2 = workoutState.latestSpO2,
+                        calories = workoutState.calories,
                         isPaused = workoutState.isPaused,
                         hrZone = workoutState.hrZone,
                         onPause = {

--- a/app/src/main/java/com/pulseloop/ui/screens/RecordScreen.kt
+++ b/app/src/main/java/com/pulseloop/ui/screens/RecordScreen.kt
@@ -26,6 +26,7 @@ fun RecordScreen(
     distanceMeters: Double = 0.0,
     heartRate: Int? = null,
     spO2: Int? = null,
+    calories: Double = 0.0,
     isPaused: Boolean = false,
     hrZone: HeartRateZones.Zone = HeartRateZones.Zone.REST,
     onPause: () -> Unit = {},
@@ -73,7 +74,7 @@ fun RecordScreen(
             item { StatTile("Distance", if (distanceMeters >= 1000) "%.1f km".format(distanceMeters / 1000) else "%.0f m".format(distanceMeters)) }
             item { StatTile("Pace", pace) }
             item { StatTile("SpO₂", spO2?.let { "$it%" } ?: "--") }
-            item { StatTile("Calories", "--") }
+            item { StatTile("Calories", if (calories >= 1) "%.0f kcal".format(calories) else "--") }
         }
 
         Spacer(Modifier.weight(1f))

--- a/app/src/main/java/com/pulseloop/ui/screens/Screens.kt
+++ b/app/src/main/java/com/pulseloop/ui/screens/Screens.kt
@@ -912,11 +912,17 @@ fun ActivityScreen(
         }
 
         item {
-            Button(
-                onClick = { navController?.navigate("record") },
-                modifier = Modifier.fillMaxWidth().height(48.dp),
-            ) {
-                Text("Start Workout")
+            // Type picks the calorie model and sensors: Weights gets a MET floor
+            // (HR misses anaerobic load), Cycling records a GPS route/distance.
+            Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                listOf("Workout", "Cycling", "Weights").forEach { type ->
+                    Button(
+                        onClick = { navController?.navigate("record/$type") },
+                        modifier = Modifier.weight(1f).height(48.dp),
+                    ) {
+                        Text(type)
+                    }
+                }
             }
         }
     }

--- a/app/src/main/java/com/pulseloop/ui/screens/Screens.kt
+++ b/app/src/main/java/com/pulseloop/ui/screens/Screens.kt
@@ -278,6 +278,13 @@ fun TodayScreen(
  * Vitals dashboard — ported from VitalsView.swift.
  * Shows historical trends: HR, SpO2, HRV, stress, temperature with real data from Room.
  */
+/** Readings per HRV series (~45s each + gap → roughly a 10-minute pass). */
+private const val HRV_PASS_SAMPLES = 10
+/** Pause between series measurements — lets the ring's sensor settle. */
+private const val HRV_PASS_GAP_MS = 15_000L
+/** Hard cap on a series — retrying dropped windows must not run unbounded. */
+private const val HRV_PASS_MAX_MS = 20 * 60_000L
+
 @Composable
 fun VitalsScreen(
     navController: androidx.navigation.NavController? = null,
@@ -288,6 +295,7 @@ fun VitalsScreen(
     val scope = rememberCoroutineScope()
     var measuring by remember { mutableStateOf(false) }
     var remaining by remember { mutableStateOf(0) }
+    var passSample by remember { mutableStateOf(0) }  // >0 while an HRV series is running
     val measureSeconds = com.pulseloop.service.RingSyncCoordinator.COMBINED_MEASURE_SECONDS
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
@@ -304,30 +312,75 @@ fun VitalsScreen(
                 // fatigue and blood sugar — the same flow the official app's "Measurement" button uses.
                 // Only shown for rings that support BP or blood sugar (56ff/Jring).
                 if (coordinator != null && (state.supportsBP || state.supportsGlucose)) {
-                    Button(
-                        enabled = !measuring,
-                        onClick = {
-                            measuring = true
-                            remaining = measureSeconds
-                            scope.launch {
-                                val ticker = launch {
-                                    while (remaining > 0) { kotlinx.coroutines.delay(1000); remaining-- }
+                    Column(horizontalAlignment = Alignment.End, verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                        Button(
+                            enabled = !measuring,
+                            onClick = {
+                                measuring = true
+                                remaining = measureSeconds
+                                scope.launch {
+                                    val ticker = launch {
+                                        while (remaining > 0) { kotlinx.coroutines.delay(1000); remaining-- }
+                                    }
+                                    try {
+                                        coordinator.measureCombined()
+                                    } finally {
+                                        ticker.cancel()
+                                        remaining = 0
+                                        measuring = false
+                                        viewModel?.refreshNow()  // show the new reading immediately
+                                    }
                                 }
-                                try {
-                                    coordinator.measureCombined()
-                                } finally {
-                                    ticker.cancel()
-                                    remaining = 0
-                                    measuring = false
-                                    viewModel?.refreshNow()  // show the new reading immediately
-                                }
+                            },
+                        ) {
+                            Text(
+                                if (measuring) "Measuring… ${remaining}s" else "Measure",
+                                color = androidx.compose.ui.graphics.Color.White,
+                            )
+                        }
+                        // HRV series: combined measurements until N discrete HRV readings
+                        // actually arrive (a window can silently produce nothing when the
+                        // BLE link drops mid-pass), capped at HRV_PASS_MAX_MS. Stay on
+                        // this screen; the loop lives in this screen's coroutine scope.
+                        if (state.supportsHrv) {
+                            OutlinedButton(
+                                enabled = !measuring,
+                                onClick = {
+                                    measuring = true
+                                    scope.launch {
+                                        val deadline = System.currentTimeMillis() + HRV_PASS_MAX_MS
+                                        var collected = 0
+                                        try {
+                                            while (collected < HRV_PASS_SAMPLES &&
+                                                System.currentTimeMillis() < deadline) {
+                                                passSample = collected + 1
+                                                val before = coordinator.hrvSampleCount
+                                                remaining = measureSeconds
+                                                val ticker = launch {
+                                                    while (remaining > 0) { kotlinx.coroutines.delay(1000); remaining-- }
+                                                }
+                                                try {
+                                                    coordinator.measureCombined()
+                                                } finally {
+                                                    ticker.cancel()
+                                                    remaining = 0
+                                                }
+                                                if (coordinator.hrvSampleCount > before) {
+                                                    collected++
+                                                    viewModel?.refreshNow()
+                                                }
+                                                if (collected < HRV_PASS_SAMPLES) kotlinx.coroutines.delay(HRV_PASS_GAP_MS)
+                                            }
+                                        } finally {
+                                            passSample = 0
+                                            measuring = false
+                                        }
+                                    }
+                                },
+                            ) {
+                                Text(if (passSample > 0) "Sample $passSample/$HRV_PASS_SAMPLES" else "HRV ×$HRV_PASS_SAMPLES")
                             }
-                        },
-                    ) {
-                        Text(
-                            if (measuring) "Measuring… ${remaining}s" else "Measure",
-                            color = androidx.compose.ui.graphics.Color.White,
-                        )
+                        }
                     }
                 }
             }
@@ -338,7 +391,10 @@ fun VitalsScreen(
                     modifier = Modifier.fillMaxWidth(),
                 )
                 Text(
-                    "Keep still — measuring blood pressure, SpO₂, stress, fatigue & blood sugar…",
+                    if (passSample > 0)
+                        "HRV series: sample $passSample of $HRV_PASS_SAMPLES — keep still and stay on this screen…"
+                    else
+                        "Keep still — measuring blood pressure, SpO₂, stress, fatigue & blood sugar…",
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     modifier = Modifier.padding(top = 4.dp),

--- a/app/src/test/java/com/pulseloop/ring/RingDecoderTest.kt
+++ b/app/src/test/java/com/pulseloop/ring/RingDecoderTest.kt
@@ -84,9 +84,11 @@ class RingDecoderTest {
         payload[4] = 40.toByte()   // fatigue at byte[5]
         payload[5] = 30.toByte()   // stress at byte[6]
         payload[6] = 51.toByte()   // blood sugar ×10 at byte[7] → 5.1 mmol/L → 91.88 mg/dL
+        payload[7] = 45.toByte()   // HRV at byte[8]
         val data = composeRingPacket(0x24, payload)
         val events = RingDecoder.decode(data)
-        assertTrue(events.size >= 6) // HR + systolic + diastolic + SpO2 + fatigue + stress + sugar
+        assertTrue(events.size >= 7) // HR + systolic + diastolic + SpO2 + fatigue + stress + sugar + HRV
+        assertTrue(events.any { it is RingDecodedEvent.HrvSample && (it as RingDecodedEvent.HrvSample).value == 45 })
         assertTrue(events.any { it is RingDecodedEvent.HeartRateSample && (it as RingDecodedEvent.HeartRateSample).bpm == 72 })
         assertTrue(events.any { it is RingDecodedEvent.Spo2Result && (it as RingDecodedEvent.Spo2Result).value == 97 })
         assertTrue(events.any { it is RingDecodedEvent.StressSample && (it as RingDecodedEvent.StressSample).value == 30 })

--- a/app/src/test/java/com/pulseloop/service/CaloriesTest.kt
+++ b/app/src/test/java/com/pulseloop/service/CaloriesTest.kt
@@ -23,4 +23,19 @@ class CaloriesTest {
     fun `keytel never negative`() {
         assertTrue(keytelKcalPerMinute(40, 50.0, 20, male = false) >= 0.0)
     }
+
+    @Test
+    fun `weights MET floor beats keytel at resting HR`() {
+        // Between sets HR drops toward rest; the 4-MET floor must carry the burn.
+        // 75kg → 4.0 × 3.5 × 75 / 200 = 5.25 kcal/min
+        val floor = metFloorKcalPerMinute("Weights", 75.0)
+        assertEquals(5.25, floor, 0.01)
+        assertTrue(floor > keytelKcalPerMinute(70, 75.0, 35, male = true))
+    }
+
+    @Test
+    fun `aerobic types have no MET floor`() {
+        assertEquals(0.0, metFloorKcalPerMinute("Cycling", 75.0), 0.0)
+        assertEquals(0.0, metFloorKcalPerMinute("Workout", 75.0), 0.0)
+    }
 }

--- a/app/src/test/java/com/pulseloop/service/CaloriesTest.kt
+++ b/app/src/test/java/com/pulseloop/service/CaloriesTest.kt
@@ -1,0 +1,26 @@
+package com.pulseloop.service
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CaloriesTest {
+    @Test
+    fun `keytel is plausible at running HR`() {
+        // 35yo male, 75kg, HR 140 → ~13 kcal/min (moderate run)
+        val kcal = keytelKcalPerMinute(140, 75.0, 35, male = true)
+        assertEquals(13.2, kcal, 0.5)
+    }
+
+    @Test
+    fun `keytel increases with HR`() {
+        val low = keytelKcalPerMinute(80, 75.0, 35, male = true)
+        val high = keytelKcalPerMinute(150, 75.0, 35, male = true)
+        assertTrue(high > low)
+    }
+
+    @Test
+    fun `keytel never negative`() {
+        assertTrue(keytelKcalPerMinute(40, 50.0, 20, male = false) >= 0.0)
+    }
+}


### PR DESCRIPTION
## Summary

Two feature areas, tested on-device (Pixel 6 Pro + factory Jring SMART_RING). Builds on #7 (its commit is included in this branch's history).

### HRV (Jring)

- The 0x24 combined-measurement packet carries HRV in byte 8 (matches the official app's `onReceiveSensorData` i8), but the decoder stopped at byte 7. Now decoded into the existing `HrvSample` event; `HRV` capability declared for the Jring (spot-only — the protocol has no HRV history sync, unlike Colmi's 0x39).
- Vitals gains an "HRV ×10" series button: repeated combined measurements until 10 readings actually arrive (verified against a monotonic sample counter, so windows lost to BLE drops are retried), capped at 20 min.
- **Field note:** this firmware reports HRV pinned at 80–81 ms while HR/BP/stress vary freely across an hour of readings — it may be derived rather than measured. The series feature makes that testable (e.g. post-exercise, where genuine HRV drops 20–40%).

### Workouts

- **Start was never wired**: `LiveWorkoutManager.start()` had zero callers; the Record screen was a display-only dashboard and `activity_sessions` stayed empty forever. Entering the record route now starts the session.
- **FGS crash-loop fix**: the manifest declared FGS type `health`, which on targetSDK 35 requires runtime permissions never requested (`ACTIVITY_RECOGNITION`/`BODY_SENSORS`) — the first real workout crash-looped via `START_STICKY`. Switched to `connectedDevice` (prerequisite `BLUETOOTH_CONNECT`, already required for the ring), plus a try/catch so any future rejection degrades to no-notification instead of a loop.
- **Persistence**: on startup, re-attach to a session still marked recording/paused in Room (rotation, process death); elapsed derives from `startedAt`; sessions older than 12 h are cancelled as crash leftovers.
- **Calories**: Keytel HR formula (profile weight/age/sex) accumulated per tick, persisted across pause/finish/re-attach, shown live.
- **Types**: Workout / Cycling / Weights buttons. Weights gets a 4-MET resistance-training floor under the HR estimate (HR misses anaerobic load between sets) and no GPS; Cycling/Workout record a GPS route when location permission is granted.

## Testing

- Unit tests added: HRV byte decode, Keytel plausibility/monotonicity/floor, MET floor values. Full suite run — the 8 failing tests are pre-existing on main (verified by stashing this work).
- On-device: session rows persist, HR streams live during workouts, notification with pause/stop works, re-attach after process death restores elapsed/calories, no crash loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)