### PR TITLE
fix(colmi): full 0x16 HR record + capability-gated bonding for R09 (auto-HR + pairing)

### DIFF
--- a/app/src/main/java/com/pulseloop/ring/ColmiDecoder.kt
+++ b/app/src/main/java/com/pulseloop/ring/ColmiDecoder.kt
@@ -226,6 +226,20 @@ object ColmiDecoder {
         return v[3].toInt() == 0x01
     }
 
+    /**
+     * Decode a `0x3C` device-support reply and return whether the ring wants an OS-level bond.
+     * Frame layout mirrors QRing's `DeviceSupportFunctionRsp.acceptData`: opcode at `[0]`, the
+     * first feature byte at `[1]`, where bit 3 (`0x08`) is `supportBlePair`. Returns null for any
+     * frame that isn't a device-support reply — callers treat null as "not a bond signal", so a
+     * wrong guess degrades to today's no-bond behaviour rather than misbehaving.
+     */
+    fun decodeDeviceSupport(data: ByteArray): Boolean? {
+        val packet = ColmiPacket.validating(data) ?: return null
+        val v = packet.bytes.map { it.toUByte() }
+        if (v[0] != ColmiCommandID.DEVICE_SUPPORT) return null
+        return (v[1].toInt() and 0x08) != 0
+    }
+
     // MARK: Big-data (V2)
 
     fun decodeBigData(

--- a/app/src/main/java/com/pulseloop/ring/ColmiEncoder.kt
+++ b/app/src/main/java/com/pulseloop/ring/ColmiEncoder.kt
@@ -50,10 +50,18 @@ object ColmiEncoder {
 
     /**
      * Enable/disable all-day **heart-rate** monitoring. Auto-HR (`0x16`) has a different shape from
-     * the other prefs (per GadgetBridge `onSetHeartRateMeasurementInterval`): the on/off flag is
-     * `0x01`(on)/`0x02`(off) — *not* `0x01`/`0x00` — and it carries the sampling interval in minutes.
-     * The interval is rounded to a 5-minute multiple, 5…60. Without this the ring records no
-     * background HR, so the HR-history sync (`0x15`) comes back empty.
+     * the other prefs: the on/off flag is `0x01`(on)/`0x02`(off) — *not* `0x01`/`0x00` — and it
+     * carries the sampling interval in minutes (rounded to a 5-minute multiple, 5…60). Without this
+     * the ring records no background HR, so the HR-history sync (`0x15`) comes back empty.
+     *
+     * The payload is the **full 7-field record** the official QRing app sends
+     * (`HeartRateSettingReq.getWriteInstance`, Oudmon SDK): after the interval come
+     * `hrStart, hrTooLow, hrTooHigh, hrTooSwitch`. Older R02 firmware accepts the short
+     * 4-byte form, but newer RT-series firmware (e.g. R09 / RT09) ACKs the short frame yet
+     * never arms background sampling — HR then only measures on a physical button press.
+     * Sending the full record (alarm fields zeroed = "no HR alerts configured", exactly what
+     * QRing sends when the user hasn't set alarms) fixes auto-HR on R09 with no R02 regression.
+     * See docs/qring-ble-adoption.md §Auto-HR.
      */
     fun autoHeartRate(enabled: Boolean, intervalMinutes: Int = 5): ByteArray {
         val interval = ((intervalMinutes / 5) * 5).coerceIn(5, 60)
@@ -62,8 +70,20 @@ object ColmiEncoder {
             ColmiCommandID.PREF_WRITE.toByte(),
             if (enabled) 0x01 else 0x02,
             interval.toByte(),
+            // hrStart, hrTooLow, hrTooHigh, hrTooSwitch — 0 = no HR alarms (hrStart 0 → the
+            // firmware's own 5-min default). The four trailing bytes are what newer firmware
+            // requires to treat this as a complete HR-setting write.
+            0x00, 0x00, 0x00, 0x00,
         )
     }
+
+    /**
+     * Read the ring's device-support/capability bitfield (QRing `DeviceSupportReq`, opcode
+     * `0x3C`, no sub-data). The reply is parsed by [ColmiDecoder.decodeDeviceSupport]; its
+     * `supportBlePair` bit tells us whether to create an OS-level bond, mirroring the official
+     * app. See docs/qring-ble-adoption.md §Pairing.
+     */
+    fun deviceSupport(): ByteArray = byteArrayOf(ColmiCommandID.DEVICE_SUPPORT.toByte())
 
     fun readTempPref(): ByteArray = byteArrayOf(
         ColmiCommandID.AUTO_TEMP_PREF.toByte(), 0x03, ColmiCommandID.PREF_READ.toByte()

--- a/app/src/main/java/com/pulseloop/ring/ColmiProtocol.kt
+++ b/app/src/main/java/com/pulseloop/ring/ColmiProtocol.kt
@@ -32,6 +32,10 @@ object ColmiCommandID {
     const val AUTO_HRV_PREF: UByte = 0x38u
     const val SYNC_HRV: UByte = 0x39u
     const val AUTO_TEMP_PREF: UByte = 0x3Au
+    // Device-support / capability bitfield read (QRing DeviceSupportReq, opcode 60). The
+    // reply's byte[1] carries feature bits; bit 3 (0x08) = supportBlePair — the ring wants
+    // an OS-level bond. Free opcode in this map (see docs/qring-ble-adoption.md).
+    const val DEVICE_SUPPORT: UByte = 0x3Cu
     const val SYNC_ACTIVITY: UByte = 0x43u
     const val BP_READ: UByte = 0x14u
     const val BP_CONFIRM: UByte = 0x0Eu

--- a/app/src/main/java/com/pulseloop/ring/ColmiSyncEngine.kt
+++ b/app/src/main/java/com/pulseloop/ring/ColmiSyncEngine.kt
@@ -29,6 +29,10 @@ class ColmiSyncEngine(
     /** Sink for the config seeded from the ring's pref-read replies (no persisted config). */
     private var onConfigSeeded: ((MeasurementSettings) -> Unit)? = null
 
+    /** Invoked when the ring's device-support reply advertises `supportBlePair`; the BLE client
+     *  creates the OS bond in response (mirrors the official QRing app). */
+    private var onBondRequested: (() -> Unit)? = null
+
     // Read-reply seeding state: collected until both the auto-HR and temp prefs reported.
     private var seedingFromRing = false
     private var seededHrIntervalMinutes: Int? = null
@@ -70,6 +74,9 @@ class ColmiSyncEngine(
         writer?.enqueue(encoder.phoneName())
         writer?.enqueue(encoder.setDateTime())
         writer?.enqueue(userPreferencesCommand())
+        // Read the ring's capability bitfield early: the reply's supportBlePair bit drives the
+        // OS bond (see handleRawNotify → onBondRequested). Harmless on rings that don't answer.
+        writer?.enqueue(encoder.deviceSupport())
         writer?.enqueue(encoder.battery())
         writer?.enqueue(encoder.readPref(ColmiCommandID.AUTO_HR_PREF))
         writer?.enqueue(encoder.readPref(ColmiCommandID.AUTO_STRESS_PREF))
@@ -108,6 +115,10 @@ class ColmiSyncEngine(
         onConfigSeeded = callback
     }
 
+    override fun setOnBondRequested(callback: () -> Unit) {
+        onBondRequested = callback
+    }
+
     /**
      * Consume the connect handshake's pref-read replies while seeding (no persisted config).
      * One exception to "the ring's settings win": all-day HR must be ON or the `0x15` HR
@@ -115,6 +126,12 @@ class ColmiSyncEngine(
      * the ring's reported interval.
      */
     override fun handleRawNotify(data: ByteArray) {
+        // Device-support reply is independent of config seeding: if the ring wants a bond, ask
+        // the client to create one. Return early — a 0x3C frame carries nothing else we consume.
+        decoder.decodeDeviceSupport(data)?.let { supportsBlePair ->
+            if (supportsBlePair) onBondRequested?.invoke()
+            return
+        }
         if (!seedingFromRing) return
         decoder.decodeAutoHRPrefRead(data)?.let { readout ->
             val interval = if (readout.intervalMinutes in 5..60) readout.intervalMinutes else 5

--- a/app/src/main/java/com/pulseloop/ring/RingBLEClient.kt
+++ b/app/src/main/java/com/pulseloop/ring/RingBLEClient.kt
@@ -597,17 +597,30 @@ class RingBLEClient(private val context: Context) {
      * Idempotent: skipped when already bonded/bonding, so it fires at most once per ring. Runs
      * after service discovery (the reply that triggers it arrives post-CONNECTED), so it does
      * not race discoverServices()/requestMtu().
+     *
+     * It also waits for the GATT op queue to fall idle before calling createBond(). The
+     * device-support (0x3C) reply lands mid-startup, while the battery/pref reads, seeding
+     * writes, and the first history-sync request are still queued or in flight. createBond()
+     * on a busy link can force a transient disconnect/re-encrypt on some firmware, dropping
+     * those in-flight ops — the very churn bonding is meant to end. Bonding in a quiet gap
+     * (no op in flight) avoids interrupting an active transfer; the wait is bounded, so a
+     * long-running sync still bonds after [awaitOpsFlushed]'s timeout rather than never.
      */
     private fun bondActiveDevice() {
         if (!hasPermissions()) return
-        val device = bluetoothGatt?.device ?: return
-        try {
-            if (device.bondState == BluetoothDevice.BOND_NONE) {
-                Log.i("RingBLEClient", "Ring advertises supportBlePair — creating OS bond")
-                device.createBond()
+        scope.launch {
+            awaitOpsFlushed()
+            // The link may have dropped while we waited for the queue to settle.
+            if (!hasPermissions()) return@launch
+            val device = bluetoothGatt?.device ?: return@launch
+            try {
+                if (device.bondState == BluetoothDevice.BOND_NONE) {
+                    Log.i("RingBLEClient", "Ring advertises supportBlePair — creating OS bond")
+                    device.createBond()
+                }
+            } catch (e: Exception) {
+                Log.w("RingBLEClient", "createBond() failed: ${e.message}")
             }
-        } catch (e: Exception) {
-            Log.w("RingBLEClient", "createBond() failed: ${e.message}")
         }
     }
 

--- a/app/src/main/java/com/pulseloop/ring/RingBLEClient.kt
+++ b/app/src/main/java/com/pulseloop/ring/RingBLEClient.kt
@@ -325,6 +325,23 @@ class RingBLEClient(private val context: Context) {
 
     private fun connectionWatchdogTick() {
         if (!bluetoothAdapter.isEnabled || !hasPermissions()) return
+        // Time out a hung CONNECTING attempt FIRST — before the last-known-ring guard below —
+        // so it also covers a first-ever pairing (no stored ring yet). The official QRing app
+        // arms this timeout on every connect (mTimeoutRunnable). Without it, a first pair that
+        // stalls after connectGatt (CCCD write dropped, GATT-133, or a link the firmware won't
+        // hold without a bond) sits on "Connecting…" forever with no exit.
+        if (_state.value.connectionState == RingConnectionState.CONNECTING) {
+            if (connectingStartedAt > 0 &&
+                System.currentTimeMillis() - connectingStartedAt > CONNECT_TIMEOUT_MS) {
+                Log.w("RingBLEClient", "Connect attempt hung >${CONNECT_TIMEOUT_MS}ms")
+                // A reconnect can retry the stored ring; a first pair has nothing to retry, so
+                // fail the attempt cleanly and surface an error rather than spinning.
+                if (lastKnownIdentifier != null) forceReconnect()
+                else failConnectAttempt(
+                    "Couldn't connect to the ring. Make sure it's nearby and awake, then try again.")
+            }
+            return
+        }
         if (lastKnownIdentifier == null) return
         when (_state.value.connectionState) {
             RingConnectionState.CONNECTED -> {
@@ -355,15 +372,7 @@ class RingBLEClient(private val context: Context) {
             RingConnectionState.DISCONNECTED,
             RingConnectionState.FAILED,
             RingConnectionState.IDLE -> connectLastKnown()
-            RingConnectionState.CONNECTING -> {
-                // A reconnect can hang indefinitely (autoConnect pending against a device
-                // that never re-advertises). Time it out and retry with a fresh GATT.
-                if (connectingStartedAt > 0 &&
-                    System.currentTimeMillis() - connectingStartedAt > CONNECT_TIMEOUT_MS) {
-                    Log.w("RingBLEClient", "Connect attempt hung >${CONNECT_TIMEOUT_MS}ms — retrying")
-                    forceReconnect()
-                }
-            }
+            // CONNECTING is handled above (before the last-known-ring guard).
             else -> {
                 // SCANNING: a pairing scan proceeds untouched, but a reconnect scan that
                 // ran a full watchdog interval without sighting the ring moves on to the
@@ -377,6 +386,27 @@ class RingBLEClient(private val context: Context) {
     private fun forceReconnect() {
         // beginConnect (via connectLastKnown) closes the stale GATT before opening a new one.
         connectLastKnown()
+    }
+
+    /**
+     * Abort a stalled connect attempt that has no stored ring to retry (a first pairing that
+     * hung). Tears the half-open GATT down and surfaces an error so the pairing UI leaves the
+     * "Connecting…" state instead of spinning forever.
+     */
+    private fun failConnectAttempt(reason: String) {
+        val gatt = bluetoothGatt
+        bluetoothGatt = null
+        writeChar = null; commandChar = null; notifyChars.clear(); batteryChar = null
+        resetOpQueue()
+        if (gatt != null) {
+            try { gatt.disconnect() } catch (_: Exception) {}
+            closeGattQuietly(gatt)
+        }
+        connectingStartedAt = 0
+        updateState { copy(connectionState = RingConnectionState.FAILED, lastError = reason) }
+        PulseEventBus.publishBlocking(
+            PulseEvent.DeviceStateChanged(RingConnectionState.DISCONNECTED, null)
+        )
     }
 
     /**
@@ -558,6 +588,30 @@ class RingBLEClient(private val context: Context) {
     }
 
     /**
+     * Create an OS-level bond with the connected ring — invoked by the sync engine only when
+     * the ring's device-support reply advertises `supportBlePair` (Colmi R09 and newer). The
+     * official QRing app does exactly this, which is why its rings appear in the phone's
+     * paired-devices list and hold a stable link; connecting GATT-only (no bond) is what left
+     * PulseLoop's users stuck on "Connecting" and cycling Bluetooth to recover.
+     *
+     * Idempotent: skipped when already bonded/bonding, so it fires at most once per ring. Runs
+     * after service discovery (the reply that triggers it arrives post-CONNECTED), so it does
+     * not race discoverServices()/requestMtu().
+     */
+    private fun bondActiveDevice() {
+        if (!hasPermissions()) return
+        val device = bluetoothGatt?.device ?: return
+        try {
+            if (device.bondState == BluetoothDevice.BOND_NONE) {
+                Log.i("RingBLEClient", "Ring advertises supportBlePair — creating OS bond")
+                device.createBond()
+            }
+        } catch (e: Exception) {
+            Log.w("RingBLEClient", "createBond() failed: ${e.message}")
+        }
+    }
+
+    /**
      * Send a keepalive ping every 15s to prevent the ring's ~20s idle timeout.
      * **Jring (56ff) only.** 0x3A is that SDK's lightweight ping/pong command; on the
      * Colmi/QRing protocol the same opcode is CMD_DEVICE_SUGAR_LIPIDS — not a ping —
@@ -589,6 +643,9 @@ class RingBLEClient(private val context: Context) {
         activeCoordinator = coordinator
         activeDriver = driver
         activeSyncEngine = driver.makeSyncEngine()
+        // Capability-gated bonding: the engine fires this only when the ring's device-support
+        // reply advertises supportBlePair (Colmi R09 and newer). See docs/qring-ble-adoption.md.
+        activeSyncEngine?.setOnBondRequested { bondActiveDevice() }
         updateState {
             copy(
                 activeDeviceType = coordinator.deviceType,
@@ -784,16 +841,15 @@ class RingBLEClient(private val context: Context) {
                 BluetoothProfile.STATE_CONNECTED -> {
                     if (status == BluetoothGatt.GATT_SUCCESS) {
                         bluetoothGatt = gatt
-                        // Do NOT create an OS-level bond. The 56ff protocol is unencrypted
-                        // (verified in the official SDK's SampleGattAttributes — no auth on
-                        // 33f3/33f4), so bonding is not required to read/write characteristics.
-                        // We intentionally skip it because bonding:
-                        //   (a) makes the OS treat the ring as a connected BT device, which is
-                        //       what lights up the phone's status-bar Bluetooth icon, and
-                        //   (b) previously ran here racing requestMtu()/discoverServices(),
-                        //       a known Android instability that caused the frequent disconnects.
-                        // Jring links are kept alive by the 0x3A keepalive; Colmi links idle
-                        // (official behavior) and the watchdog reconnects when they drop.
+                        // Do NOT bond *here*. Bonding at connect time raced
+                        // requestMtu()/discoverServices() — a known Android instability that
+                        // caused frequent disconnects. Instead we bond later, and only when the
+                        // ring asks: the Colmi engine reads the device-support bitfield during
+                        // startup and, if supportBlePair is set (R09 and newer), calls back into
+                        // bondActiveDevice() — well after discovery, matching the official QRing
+                        // app (which also bonds post-discovery, gated on supportBlePair). Rings
+                        // that don't advertise the bit (jring 56ff, older R02) are never bonded,
+                        // preserving prior behaviour. See docs/qring-ble-adoption.md §Pairing.
                         // Request a high-priority connection interval, matching the official app
                         // (BluetoothLeService.requestConnectionPriority(1) on connect).
                         gatt.requestConnectionPriority(BluetoothGatt.CONNECTION_PRIORITY_HIGH)

--- a/app/src/main/java/com/pulseloop/ring/WearableDriver.kt
+++ b/app/src/main/java/com/pulseloop/ring/WearableDriver.kt
@@ -135,6 +135,11 @@ interface RingSyncEngine {
      *  the decoded-event stream doesn't carry (e.g. Colmi pref-read replies) hook in here. */
     fun handleRawNotify(data: ByteArray) {}
 
+    /** Register a callback the engine invokes when the connected ring reports that it wants an
+     *  OS-level Bluetooth bond (Colmi `supportBlePair`). The client owns the actual
+     *  [android.bluetooth.BluetoothDevice.createBond] call. No-op if unsupported. */
+    fun setOnBondRequested(callback: () -> Unit) {}
+
     /** Store the user's profile *without* sending — the connect handshake sends it. No-op if unsupported. */
     fun setUserProfile(profile: UserProfileValues) {}
 

--- a/app/src/test/java/com/pulseloop/ring/ColmiDecoderTest.kt
+++ b/app/src/test/java/com/pulseloop/ring/ColmiDecoderTest.kt
@@ -395,18 +395,33 @@ class ColmiDecoderTest {
     }
 
     // Auto-HR (0x16) has a different shape from the other prefs: on/off is 0x01/0x02
-    // (not 0x01/0x00) and carries the sampling interval in minutes. Parity with
-    // ColmiDecoderTests.swift (PR #17).
+    // (not 0x01/0x00) and carries the sampling interval in minutes, then the four trailing
+    // fields the official QRing app sends (hrStart, hrTooLow, hrTooHigh, hrTooSwitch — all 0
+    // = no HR alarms). The full record is required by newer RT-series firmware (R09) to arm
+    // background HR. See docs/qring-ble-adoption.md §Auto-HR.
     @Test
-    fun `auto heart rate enable carries 0x01 flag and interval`() {
+    fun `auto heart rate enable carries 0x01 flag, interval and zeroed alarm fields`() {
         val cmd = ColmiEncoder.autoHeartRate(enabled = true, intervalMinutes = 5)
-        assertArrayEquals(byteArrayOf(0x16, 0x02, 0x01, 0x05), cmd)
+        assertArrayEquals(byteArrayOf(0x16, 0x02, 0x01, 0x05, 0x00, 0x00, 0x00, 0x00), cmd)
     }
 
     @Test
     fun `auto heart rate disable uses 0x02 flag`() {
         val cmd = ColmiEncoder.autoHeartRate(enabled = false, intervalMinutes = 5)
-        assertArrayEquals(byteArrayOf(0x16, 0x02, 0x02, 0x05), cmd)
+        assertArrayEquals(byteArrayOf(0x16, 0x02, 0x02, 0x05, 0x00, 0x00, 0x00, 0x00), cmd)
+    }
+
+    // Device-support (0x3C): supportBlePair is bit 3 (0x08) of the first feature byte (frame[1]).
+    @Test
+    fun `device support decodes supportBlePair bit`() {
+        // frame[1] = 0x08 → bond wanted
+        assertEquals(true, ColmiDecoder.decodeDeviceSupport(ColmiPacket.frame(byteArrayOf(0x3C, 0x08))))
+        // frame[1] = 0x0F (bit set among others) → still true
+        assertEquals(true, ColmiDecoder.decodeDeviceSupport(ColmiPacket.frame(byteArrayOf(0x3C, 0x0F))))
+        // frame[1] = 0x07 (bit clear) → false
+        assertEquals(false, ColmiDecoder.decodeDeviceSupport(ColmiPacket.frame(byteArrayOf(0x3C, 0x07))))
+        // Not a device-support frame → null
+        assertNull(ColmiDecoder.decodeDeviceSupport(ColmiPacket.frame(byteArrayOf(0x16, 0x01, 0x01, 30))))
     }
 
     @Test

--- a/app/src/test/java/com/pulseloop/ring/ColmiMeasurementSettingsTest.kt
+++ b/app/src/test/java/com/pulseloop/ring/ColmiMeasurementSettingsTest.kt
@@ -58,7 +58,7 @@ class ColmiMeasurementSettingsTest {
         engine.runStartup()
         engine.destroy()
 
-        val autoHr = writer.commands.first { it[0] == 0x16.toByte() && it.size == 4 && it[1] == 0x02.toByte() }
+        val autoHr = writer.commands.first { it[0] == 0x16.toByte() && it.size == 8 && it[1] == 0x02.toByte() }
         assertEquals(0x01.toByte(), autoHr[2])       // enabled
         assertEquals(15.toByte(), autoHr[3])         // configured interval
         val stress = writer.commands.first { it[0] == 0x36.toByte() && it[1] == 0x02.toByte() }
@@ -190,5 +190,35 @@ class ColmiMeasurementSettingsTest {
     fun `colmi declares the measurement interval capability, jring does not`() {
         assertTrue(ColmiCoordinator.capabilities.contains(WearableCapability.MEASUREMENT_INTERVAL))
         assertTrue(!JringCoordinator.capabilities.contains(WearableCapability.MEASUREMENT_INTERVAL))
+    }
+
+    // MARK: Capability-gated bonding (QRing supportBlePair)
+
+    @Test
+    fun `startup reads the device-support capability bitfield`() {
+        val writer = RecordingWriter()
+        val engine = ColmiSyncEngine(writer, ColmiDecoder)
+        engine.setMeasurementSettings(null)
+        engine.runStartup()
+        engine.destroy()
+
+        assertTrue(writer.commands.any { it[0] == 0x3C.toByte() })  // DeviceSupportReq
+    }
+
+    @Test
+    fun `supportBlePair reply requests a bond, non-support reply does not`() {
+        val writer = RecordingWriter()
+        val engine = ColmiSyncEngine(writer, ColmiDecoder)
+        var bondRequests = 0
+        engine.setOnBondRequested { bondRequests++ }
+
+        // Feature byte with bit 3 set → bond wanted.
+        engine.handleRawNotify(ColmiPacket.frame(byteArrayOf(0x3C, 0x08)))
+        assertEquals(1, bondRequests)
+
+        // Feature byte without bit 3 → no bond.
+        engine.handleRawNotify(ColmiPacket.frame(byteArrayOf(0x3C, 0x07)))
+        assertEquals(1, bondRequests)
+        engine.destroy()
     }
 }

--- a/docs/qring-ble-adoption.md
+++ b/docs/qring-ble-adoption.md
@@ -159,7 +159,11 @@ it never parsed `0x3C`. So the fix had to *teach PulseLoop to read `0x3C`* and r
   it — that ring relies on 5b instead.)
 - **No connect-time race:** the bond fires when the `0x3C` reply arrives *during startup*
   (post-CONNECTED, post-discovery), so it does NOT race `requestMtu()/discoverServices()` —
-  the original reason bonding was removed.
+  the original reason bonding was removed. The `0x3C` reply also lands while the rest of the
+  startup handshake (battery/pref reads, seeding writes, first history-sync request) is still
+  queued or in flight, so `bondActiveDevice()` first `awaitOpsFlushed()`s (bounded) and calls
+  `createBond()` only in a quiet gap — `createBond()` on a busy link can force a transient
+  re-encrypt/disconnect on some firmware that would drop those in-flight ops.
 - **Idempotent:** guarded on `BOND_NONE`, so it bonds at most once per ring.
 - **Visible UX change (intended):** the ring now appears in the phone's Bluetooth
   paired-devices list and lights the status-bar BT icon — this is the point, and matches

--- a/docs/qring-ble-adoption.md
+++ b/docs/qring-ble-adoption.md
@@ -1,0 +1,276 @@
+# QRing BLE Stack vs PulseLoop — Comparative Analysis & Safe-Adoption Guide
+
+**Audience:** an AI agent (or engineer) working on either the **Android** app
+(`foureight84/PulseLoopAndroid`, this repo) or the **iOS** app
+(`foureight84/PulseLoop`, the root repo). The two apps are behavior-parity ports of each
+other, so every rule here applies to both — file-name mappings are in
+[§9 Porting to iOS](#9-porting-to-ios).
+
+**What this documents:** how the official Colmi **QRing** app (decompiled at
+`decompiled-qring-official/` in the iOS repo root) drives its rings over BLE, how PulseLoop
+differs, and exactly how to adopt QRing's behavior **without breaking PulseLoop's own
+features**. It is the design record behind the fix on branch
+`fix/colmi-r09-autohr-and-pairing`.
+
+> **TL;DR** Two user-reported bugs, both traced to PulseLoop sending *less* than QRing:
+> 1. **R09 heart rate only measures on button press** → PulseLoop sent a truncated 4-byte
+>    `0x16` HR-settings write; newer RT-series firmware needs QRing's full 7-field record.
+> 2. **R02/R09 "cannot pair" / stuck on "Connecting"** → PulseLoop never created an OS
+>    bond (QRing does, gated on the ring's `supportBlePair` capability bit), and its
+>    connect watchdog had no timeout on a *first* pairing.
+
+---
+
+## 1. The rings and who speaks what
+
+Colmi/Yawell rings (R02, R03, R06, R09, R10, …) all speak **one** wire protocol — the
+Oudmon/"Jxr35" protocol. QRing talks to them through the `com.oudmon.ble` SDK. PulseLoop
+reimplemented the same protocol from scratch (cross-checked against `colmi_r02_client` and
+GadgetBridge). PulseLoop *also* supports a second, unrelated family — **jring / "56ff"** —
+which is NOT a Colmi ring and must never be affected by Colmi-specific changes.
+
+| | Colmi family (R02/R03/R09/R10) | jring / 56ff |
+|---|---|---|
+| PulseLoop driver | `ColmiDriver` / `ColmiSyncEngine` / `ColmiEncoder` / `ColmiDecoder` | `JringDriver` |
+| Framing | 16 bytes: 15 content + 1 checksum (`ColmiPacket.frame`) | identity / 20-byte |
+| Official app | QRing (`com.oudmon.ble`) | (other) |
+| Bonding | **Yes, if `supportBlePair`** | No (unencrypted) |
+
+**Key insight:** R09 is not a different protocol from R02 — it's the same opcodes on newer
+firmware (`RT09_*`) that is *stricter* about payload completeness and *expects* an OS bond.
+PulseLoop maps every Colmi model to one internal type `COLMI_R02` and one code path; there
+is no per-model command branching, and we did **not** add any. The fixes are firmware-safe
+supersets, not model forks.
+
+## 2. Wire framing (identical on both apps — verified)
+
+QRing `BaseReqCmd.getData()` builds `[opcode][subData…]`, zero-pads to
+`Constants.CMD_DATA_LENGTH` (16), and writes a 1-byte additive checksum in the last byte.
+This is **byte-for-byte** what PulseLoop's `ColmiPacket.frame` does. So any QRing command
+translates to PulseLoop as: *return `[opcode] + subData` as the logical payload; the driver
+frames it.* No framing work is ever needed when porting a QRing command.
+
+Decompiled refs: `sources/com/oudmon/ble/base/communication/req/BaseReqCmd.java`,
+`.../req/MixtureReq.java`.
+
+## 3. Command reference (the opcodes this analysis touched)
+
+| Opcode | Name | QRing class | PulseLoop `ColmiCommandID` | Notes |
+|---|---|---|---|---|
+| `0x16` (22) | HR all-day settings | `HeartRateSettingReq` | `AUTO_HR_PREF` | **7-field write** — see §4 |
+| `0x2C` (44) | SpO₂ auto | `BloodOxygenSettingReq` | `AUTO_SPO2_PREF` | simple on/off pref |
+| `0x36` (54) | Stress auto | `PressureSettingReq` | `AUTO_STRESS_PREF` | simple on/off pref |
+| `0x38` (56) | HRV auto | `HRVSettingReq` | `AUTO_HRV_PREF` | simple on/off pref |
+| `0x3A` (58) | Temp auto | (settings) | `AUTO_TEMP_PREF` | extra `0x03` framing byte |
+| `0x3C` (60) | **Device support / capabilities** | `DeviceSupportReq` / `DeviceSupportFunctionRsp` | `DEVICE_SUPPORT` (**added**) | carries `supportBlePair` — see §5 |
+| `0xBC` (188) | Big-data channel | `LargeDataHandler` | `BIG_DATA_V2` | **read/sync only** — NOT an enable switch |
+
+**Trap for the next investigator:** `0xBC` has `ACTION_Interval_Heart_Rate = 0x75` etc.
+These *download historical* per-interval samples; they do **not** enable monitoring. The
+enable switch is `0x16`. Don't chase the big-data path for auto-HR.
+
+## 4. Auto-HR — root cause and fix
+
+### What QRing sends
+`HeartRateSettingReq.getWriteInstance(detect, interval, hrStart, tooLow, tooHigh, tooSwitch)`
+→ subData `{2, enable(1/2), interval, hrStart, hrTooLow, hrTooHigh, hrTooSwitch}`
+(7 fields). Framed: `16 02 <enable> <interval> <hrStart> <tooLow> <tooHigh> <tooSwitch>`.
+
+Semantics, from `HeartRateSettingRsp.readSubData`:
+- `enable`: **`0x01` on / `0x02` off** (not `0x01`/`0x00`).
+- `interval`: sampling minutes.
+- `hrStart` (a.k.a. `startInterval`): defaults to **5** when 0 (a secondary interval, *not*
+  a time-of-day window — there is no matching "end" field).
+- `tooLow` / `tooHigh`: HR alarm thresholds; **0 = unset**.
+- `tooSwitch` (a.k.a. `mainSwitch`): the HR-**alarm** enable. **Not** the monitoring master
+  switch — QRing users with alarms off still get all-day HR, so `0` here is fine.
+
+### What PulseLoop sent before (the bug)
+Only the first 4 bytes: `16 02 <enable> <interval>`. Old R02 firmware accepts this and
+enables all-day HR. **Newer RT-series firmware (R09 `RT09_*`) ACKs it but never arms the
+background sampler** — so HR is only captured on a physical button press. This exactly
+matches the diagnostics: the app sent `16 02 01 05` on connect, yet no background HR was
+recorded.
+
+### The fix (implemented)
+`ColmiEncoder.autoHeartRate` now emits the full 7-field record with the four trailing bytes
+**zeroed** (= "no HR alarms configured", precisely what QRing sends when the user hasn't set
+alerts):
+```
+16 02 <01|02> <interval> 00 00 00 00
+```
+- **Zero regression risk on R02:** QRing sends this same fuller record to R02s, which work.
+- **`enable`/`interval` bytes and their positions are unchanged**, so the custom-interval
+  feature (§7) is preserved — see that section for why.
+
+Files: `ColmiEncoder.kt::autoHeartRate`. Decoder `ColmiDecoder.decodeAutoHRPrefRead` already
+reads only `v[2]`/`v[3]`, so it tolerates the longer reply unchanged.
+
+> **Confidence & validation:** this is the highest-confidence fix available without R09
+> hardware — it makes PulseLoop send exactly what the *known-working* official app sends.
+> If a future test with an R09 shows HR still off, the next hypothesis to check is whether
+> the ring's `0x16` **read reply** parses correctly on RT09 (byte offsets), because a
+> misparse would make the seeding logic believe HR is already on and skip the enable. See
+> `ColmiSyncEngine.handleRawNotify`.
+
+## 5. Pairing — root causes and fixes
+
+PulseLoop's `RingBLEClient` had already adopted most of QRing's connection discipline
+(`connectGatt(…, autoConnect=false, TRANSPORT_LE)`, `refresh()`+`close()` teardown, a
+reconnect watchdog that alternates direct-connect vs scan-then-connect by `count % 3`). Two
+gaps remained.
+
+### 5a. No OS bond (the main pairing defect)
+**QRing bonds, gated on a capability bit.** After reading the device-support response it does:
+```java
+// DeviceCmdInit.java
+if (deviceSupportFunctionRsp.supportBlePair) {   // = responseFrame[1] & 0x08
+    BleOperateManager.getInstance().bleCreateBond();   // BluetoothDevice.createBond()
+}
+```
+`bleCreateBond()` (`BleBaseControl.java`) calls the standard `createBond()` only when
+`getBondState() == BOND_NONE`. R09 firmware sets `supportBlePair`; that's why the ring shows
+in the phone's paired-devices list under QRing and holds a stable link. PulseLoop connected
+GATT-only and **never bonded** — so the ring was absent from the OS paired list and the link
+was fragile (connects once, then can't re-sync; recovery needed "forget + toggle Bluetooth").
+
+**Why PulseLoop can't copy QRing's gate verbatim:** PulseLoop derives Colmi capabilities from
+a **hardcoded static set** (`ColmiCoordinator.capabilities`), not from the ring's response —
+it never parsed `0x3C`. So the fix had to *teach PulseLoop to read `0x3C`* and route the bit.
+
+**The fix (implemented) — the "clean `supportBlePair` gate":**
+1. `ColmiCommandID.DEVICE_SUPPORT = 0x3C` + `ColmiEncoder.deviceSupport()` (opcode only,
+   no sub-data — matches QRing's `DeviceSupportReq`).
+2. `ColmiDecoder.decodeDeviceSupport(frame)` → `Boolean?`: returns `frame[1] & 0x08`, or
+   `null` if it isn't a `0x3C` frame. **Fail-safe:** a wrong guess returns `null` → no bond
+   → today's behavior, never a crash.
+3. `ColmiSyncEngine.runStartup` enqueues `deviceSupport()`; `handleRawNotify` decodes the
+   reply *before* the config-seeding guard and, if `supportBlePair`, invokes a new
+   `onBondRequested` callback.
+4. `RingSyncEngine.setOnBondRequested(cb)` (new interface hook, default no-op) is wired in
+   `RingBLEClient.installDriver` to `bondActiveDevice()`, which calls
+   `device.createBond()` when `bondState == BOND_NONE`.
+
+**Why this is safe and correctly scoped:**
+- **Colmi-only:** only `ColmiSyncEngine` ever fires the callback, and only when the ring's
+  own reply sets the bit. jring/56ff is untouched.
+- **R02-safe:** an older R02 that doesn't advertise `supportBlePair` simply won't bond →
+  identical to today. (Corollary: if some R02 *needs* a bond, this alone won't add one for
+  it — that ring relies on 5b instead.)
+- **No connect-time race:** the bond fires when the `0x3C` reply arrives *during startup*
+  (post-CONNECTED, post-discovery), so it does NOT race `requestMtu()/discoverServices()` —
+  the original reason bonding was removed.
+- **Idempotent:** guarded on `BOND_NONE`, so it bonds at most once per ring.
+- **Visible UX change (intended):** the ring now appears in the phone's Bluetooth
+  paired-devices list and lights the status-bar BT icon — this is the point, and matches
+  QRing. These rings use "just works" pairing (no passkey dialog).
+
+### 5b. Stuck on "Connecting…" forever (first pairing)
+**QRing arms a no-callback timeout on *every* connect** (`mTimeoutRunnable`, 40s in
+`BleBaseControl`): if the OS never delivers `onConnectionStateChange`, it force-disconnects
+and reports failure. PulseLoop's watchdog had a 30s connect timeout **but gated it behind
+`if (lastKnownIdentifier == null) return`** — and on a *first-ever* pairing there is no
+stored ring yet, so the timeout never ran and the attempt hung indefinitely.
+
+**The fix (implemented):** `RingBLEClient.connectionWatchdogTick` now checks the `CONNECTING`
+timeout **before** the last-known-ring guard. If a stored ring exists it reconnects
+(`forceReconnect`, unchanged); on a first pair it calls `failConnectAttempt(...)` — tears
+down the half-open GATT, sets state `FAILED` with a user-facing error, so the pairing UI
+leaves "Connecting…".
+
+### 5c. Already-present QRing behaviors (do not re-add)
+These were adopted in earlier work; noted so a porter doesn't duplicate them:
+`autoConnect=false` + `TRANSPORT_LE`; `refresh()`-via-reflection then `close()` on every
+teardown; `count % 3` direct-vs-scan reconnect alternation; a GATT-op FIFO so a dropped CCCD
+write can't hang the connection; "toggle Bluetooth" hint after 2 sightless reconnect scans.
+
+## 6. Side-by-side summary
+
+| Concern | QRing | PulseLoop before | PulseLoop after |
+|---|---|---|---|
+| Auto-HR write | 7-field `0x16` | 4-byte `0x16` (truncated) | **7-field `0x16`** |
+| Reads capabilities (`0x3C`) | yes | no | **yes** |
+| OS bond | if `supportBlePair` | never | **if `supportBlePair`** |
+| First-pair connect timeout | 40s, every attempt | none (gated out) | **30s, every attempt** |
+| Reconnect timeout | 40s | 30s (reconnect only) | 30s (reconnect only) |
+| `connectGatt` params | `false`, `TRANSPORT_LE` | same | same |
+| Teardown refresh+close | yes | yes | yes |
+
+## 7. PulseLoop custom features — confirmed unaffected
+
+PulseLoop's only material behavioral addition over QRing is the **custom data-sync /
+measurement-interval window** (iOS #19): a Settings row (shown only for rings declaring the
+`MEASUREMENT_INTERVAL` capability) where the user sets the all-day HR sampling interval and
+per-vital on/off toggles. Flow:
+`SettingsSubScreens → RingSyncCoordinator.applyMeasurementSettings →
+ColmiSyncEngine.applyMeasurementSettings → enqueueMeasurementCommands →
+ColmiEncoder.autoHeartRate(enabled, intervalMinutes)`.
+
+- **Auto-HR fix (§4):** the custom interval flows through the *same* `autoHeartRate` builder.
+  The change **only appends** trailing bytes; `enabled` and `intervalMinutes` keep their
+  positions and the existing `((interval/5)*5).coerceIn(5,60)` rounding. So the feature's
+  contract is unchanged — and on R09 it goes from *silently ignored* to *actually honored*.
+- **Pairing fix (§5):** lives entirely in the connection/bonding layer (`RingBLEClient`) and
+  the startup handshake; it shares no code with the interval/settings path. Adding the `0x3C`
+  read does not change the static capability set, so the Settings row's visibility and every
+  other capability-gated feature are untouched.
+
+There are no other PulseLoop-only ring features that these changes touch (the seed-from-ring
+config logic, realtime-HR keepalive, forget/unbind flow, and history state machine are all
+preserved).
+
+## 8. Exactly what changed (Android)
+
+| File | Change |
+|---|---|
+| `ring/ColmiProtocol.kt` | `+ DEVICE_SUPPORT = 0x3C` |
+| `ring/ColmiEncoder.kt` | `autoHeartRate` → 7-field payload; `+ deviceSupport()` |
+| `ring/ColmiDecoder.kt` | `+ decodeDeviceSupport()` |
+| `ring/WearableDriver.kt` | `+ RingSyncEngine.setOnBondRequested()` (default no-op) |
+| `ring/ColmiSyncEngine.kt` | `+ onBondRequested`; startup reads `0x3C`; `handleRawNotify` routes bond signal |
+| `ring/RingBLEClient.kt` | `+ bondActiveDevice()`; wire callback in `installDriver`; first-pair connect timeout + `failConnectAttempt()`; updated no-bond comment |
+| tests | updated 4→8-byte auto-HR asserts; `+ decodeDeviceSupport` + bond-request tests |
+
+## 9. Porting to iOS
+
+The iOS app mirrors these classes (Swift). Apply the same behavior:
+
+| Android | iOS (root repo) |
+|---|---|
+| `ColmiEncoder.kt` | `ColmiEncoder.swift` |
+| `ColmiDecoder.kt` | `ColmiDecoder.swift` |
+| `ColmiProtocol.kt` | `ColmiProtocol.swift` (`ColmiCommandID`) |
+| `ColmiSyncEngine.kt` | `ColmiSyncEngine.swift` |
+| `RingBLEClient.kt` | `RingBLEClient.swift` |
+| `WearableDriver.kt` (`RingSyncEngine`) | `WearableDriver.swift` |
+
+iOS specifics to translate:
+- **Auto-HR:** same 8-byte payload. Trivial, no platform caveats.
+- **`0x3C` read + `supportBlePair`:** same decode (`frame[1] & 0x08`), same startup enqueue
+  and engine callback.
+- **Bonding is different on iOS.** CoreBluetooth has **no `createBond()`** — bonding/pairing
+  is triggered *implicitly* by accessing an encrypted characteristic, and the OS shows the
+  pairing sheet. So the iOS equivalent of "honor `supportBlePair`" is usually a no-op at the
+  API level (iOS pairs on demand), **but** the useful ports are: (a) the **first-connect
+  timeout** (CoreBluetooth `connect(_:options:)` has no timeout — add your own timer and call
+  `cancelPeripheralConnection` on expiry, exactly like `failConnectAttempt`), and (b) do NOT
+  hold the `CBPeripheral`/central in a state that blocks re-discovery after a silent drop.
+  Verify whether iOS users even report the pairing bug before porting 5a; the auto-HR (§4)
+  and first-pair-timeout (§5b) fixes are the clearly-portable ones.
+
+## 10. Source map (for re-verification)
+
+**QRing (decompiled, in iOS repo root `decompiled-qring-official/sources/`):**
+- `com/oudmon/ble/base/communication/req/HeartRateSettingReq.java` — 7-field `0x16` write
+- `com/oudmon/ble/base/communication/rsp/HeartRateSettingRsp.java` — field semantics
+- `com/oudmon/ble/base/communication/req/DeviceSupportReq.java` — `0x3C` request (opcode 60)
+- `com/oudmon/ble/base/communication/rsp/DeviceSupportFunctionRsp.java` — `supportBlePair = byte[1] & 8`
+- `com/qcwireless/smart/ui/base/watch/DeviceCmdInit.java` — bond gate on `supportBlePair`
+- `com/oudmon/ble/base/bluetooth/BleBaseControl.java` — `bleCreateBond`, `connectGatt`,
+  `mTimeoutRunnable` (40s), `mReconnectRunnable`, `refreshDeviceCache`
+- `com/oudmon/ble/base/communication/req/BaseReqCmd.java` — 16-byte framing + checksum
+
+**Diagnostics that seeded this analysis:** a user's exported debug log showed the ring
+(`R09`, `RT09_3.10.21_251107`) receiving `16 02 01 05` on connect yet recording no background
+HR, and issue #9 reports of "not in paired list / stuck Connecting / forget+toggle to
+recover."


### PR DESCRIPTION
Fixes two user-reported Colmi issues, both traced to PulseLoop sending **less** than the official QRing app over the same protocol. Full analysis + iOS-port guide added at [`docs/qring-ble-adoption.md`](../blob/fix/colmi-r09-autohr-and-pairing/docs/qring-ble-adoption.md).

## 1. R09 heart rate only measured on button press
`ColmiEncoder.autoHeartRate` sent a **truncated 4-byte** `0x16` HR-settings write. Older R02 firmware accepts it, but newer RT-series firmware (`RT09_*`) ACKs it yet **never arms background sampling** — so HR was only captured on a physical button press. Diagnostics confirmed the app sent `16 02 01 05` on connect but recorded no background HR.

**Fix:** send QRing's **full 7-field record** — `16 02 <enable> <interval> <hrStart> <tooLow> <tooHigh> <tooSwitch>`, with the four alarm fields zeroed (exactly what QRing sends when the user hasn't configured HR alarms).
- **No R02 regression** — QRing sends this same record to R02s, which work.
- `enable`/`interval` byte positions are unchanged, so the **custom sync-interval setting is preserved** (and now actually honored on R09).

## 2. R02/R09 "cannot pair" / stuck on "Connecting"
Two independent gaps vs QRing:

**(a) No OS bond.** QRing calls `createBond()` gated on the ring's `supportBlePair` capability bit; R09 sets it, which is why QRing's rings appear in the phone's paired-devices list and hold a stable link. PulseLoop connected GATT-only and never bonded. Now: read device-support (`0x3C`) during startup, decode `byte[1] & 0x08`, and route it to `RingBLEClient.bondActiveDevice()` → `createBond()`.
- Colmi-only; fired **post-discovery** (no `requestMtu()/discoverServices()` race); **idempotent** on `BOND_NONE`.
- jring/56ff and older R02 rings that don't advertise the bit are **never bonded** → prior behavior preserved.

**(b) First-pair timeout hole.** The connect watchdog's timeout was gated behind `if (lastKnownIdentifier == null) return`, so a *first* pairing that stalled had no timeout and hung forever. Now the `CONNECTING` timeout runs before that guard; a first pair fails cleanly with a user-facing error instead of spinning.

## Safety / scope
- The **custom data-sync interval window** (iOS #19) is unaffected — auto-HR change is byte-position-compatible; pairing change shares no code with the settings path and doesn't alter the capability set. Rationale in the doc §7.
- `0x3C` is a previously-unused opcode; the decoder fails safe (unknown frame → no bond → today's behavior).

## Tests
`./gradlew :app:testDebugUnitTest` green. Updated auto-HR asserts (4→8 bytes) and added `decodeDeviceSupport` + bond-request coverage.

## Validation note
The auto-HR fix is the highest-confidence change possible without R09 hardware — it makes PulseLoop send exactly what the known-working official app sends. Would appreciate a debug-log confirmation from an R09 user once built.

Refs #9.