### PR TITLE
fix(ble): serialize MTU exchange and service discovery in connect handshake

### DIFF
--- a/app/src/main/java/com/pulseloop/ring/RingBLEClient.kt
+++ b/app/src/main/java/com/pulseloop/ring/RingBLEClient.kt
@@ -159,6 +159,20 @@ class RingBLEClient(private val context: Context) {
     private var connectingStartedAt: Long = 0L
     private var watchdogJob: Job? = null
 
+    // MARK: Service-discovery gate
+    //
+    // Android permits exactly ONE outstanding GATT operation. requestMtu() starts an ATT
+    // MTU exchange; issuing discoverServices() before that exchange's callback returns makes
+    // discoverServices() come back false and be silently dropped on strict stacks (observed
+    // on realme/Android 16 with the jring 56ff: MTU negotiated to 512, but services were
+    // never discovered, the notify-CCCD write that gates CONNECTED never ran, and the connect
+    // hung until the 30s watchdog killed it). The connect handshake runs OUTSIDE the op queue,
+    // so it needs its own serialization: request the MTU, then kick off discovery from
+    // onMtuChanged (with a fallback in case that callback never arrives). This mirrors the
+    // official QRing app (BleBaseControl), which settles ~500ms then discovers, retries once
+    // after ~1000ms if rejected, and never overlaps discovery with another GATT op.
+    private val serviceDiscoveryStarted = java.util.concurrent.atomic.AtomicBoolean(false)
+
     init { startConnectionWatchdog() }
 
     // MARK: Public API
@@ -555,6 +569,7 @@ class RingBLEClient(private val context: Context) {
         bluetoothGatt = null
         writeChar = null; commandChar = null; notifyChars.clear(); batteryChar = null
         resetOpQueue()
+        serviceDiscoveryStarted.set(false)
         val coordinator = coordinators.firstOrNull { it.deviceType == deviceType } ?: JringCoordinator
         // Resolve the exact catalog model for this connection: Bluetooth identity wins over the
         // user's carousel selection; family mismatches are rejected (iOS #49 beginConnect).
@@ -854,6 +869,7 @@ class RingBLEClient(private val context: Context) {
                 BluetoothProfile.STATE_CONNECTED -> {
                     if (status == BluetoothGatt.GATT_SUCCESS) {
                         bluetoothGatt = gatt
+                        serviceDiscoveryStarted.set(false)
                         // Do NOT bond *here*. Bonding at connect time raced
                         // requestMtu()/discoverServices() — a known Android instability that
                         // caused frequent disconnects. Instead we bond later, and only when the
@@ -866,8 +882,20 @@ class RingBLEClient(private val context: Context) {
                         // Request a high-priority connection interval, matching the official app
                         // (BluetoothLeService.requestConnectionPriority(1) on connect).
                         gatt.requestConnectionPriority(BluetoothGatt.CONNECTION_PRIORITY_HIGH)
-                        gatt.requestMtu(512)
-                        gatt.discoverServices()
+                        // Request a larger MTU (helps history-sync throughput), then discover
+                        // services ONLY after the MTU exchange completes — never overlap the two
+                        // (see serviceDiscoveryStarted). Discovery is kicked off from onMtuChanged;
+                        // if requestMtu() is rejected outright, or its callback never arrives,
+                        // fall back to discovering anyway so the connect can't hang.
+                        val mtuRequested = try { gatt.requestMtu(512) } catch (_: Exception) { false }
+                        if (!mtuRequested) {
+                            startServiceDiscovery(gatt)
+                        } else {
+                            scope.launch {
+                                delay(MTU_DISCOVERY_FALLBACK_MS)
+                                if (gatt === bluetoothGatt) startServiceDiscovery(gatt)
+                            }
+                        }
                     } else {
                         updateState { copy(lastError = "GATT connect failed: $status") }
                         handleDisconnect(gatt)
@@ -1119,7 +1147,36 @@ class RingBLEClient(private val context: Context) {
         }
 
         override fun onMtuChanged(gatt: BluetoothGatt, mtu: Int, status: Int) {
-            // No-op for Phase 2; MTU negotiation may be added later
+            if (gatt !== bluetoothGatt) return  // late callback from a superseded connection
+            // The MTU exchange has retired — the single-outstanding-op slot is free, so it is
+            // now safe to discover services (status is ignored: even a failed negotiation frees
+            // the slot, and discovery must proceed either way).
+            startServiceDiscovery(gatt)
+        }
+    }
+
+    /**
+     * Begin service discovery exactly once per connection, off the GATT-op critical path.
+     * Called from onMtuChanged (the MTU exchange has completed) or, as a fallback, a delayed
+     * job after connect — whichever fires first wins via [serviceDiscoveryStarted]. A small
+     * settle delay before discovery, plus one retry if the stack rejects it, mirrors the
+     * official QRing app (BleBaseControl: waitFor(500) → discoverServices, waitFor(1000) → retry).
+     */
+    private fun startServiceDiscovery(gatt: BluetoothGatt) {
+        if (!serviceDiscoveryStarted.compareAndSet(false, true)) return
+        scope.launch {
+            delay(SERVICE_DISCOVERY_SETTLE_MS)
+            if (gatt !== bluetoothGatt) return@launch
+            if (gatt.discoverServices()) return@launch
+            // Rejected at issue (transient busy state) — retry once after a longer pause.
+            Log.w("RingBLEClient", "discoverServices() rejected — retrying")
+            delay(SERVICE_DISCOVERY_RETRY_MS)
+            if (gatt !== bluetoothGatt) return@launch
+            if (!gatt.discoverServices()) {
+                // Still rejected: leave the CONNECTING watchdog to time the attempt out and
+                // retry from a fresh connectGatt rather than sitting half-open forever.
+                Log.w("RingBLEClient", "discoverServices() rejected twice — connect will time out")
+            }
         }
     }
 
@@ -1182,6 +1239,13 @@ class RingBLEClient(private val context: Context) {
         private const val LINK_STALE_MS = 50_000L
         /** A CONNECTING attempt that hasn't completed in this long is retried from scratch. */
         private const val CONNECT_TIMEOUT_MS = 30_000L
+        /** Settle delay after the MTU exchange before discovering services (official app: waitFor(500)). */
+        private const val SERVICE_DISCOVERY_SETTLE_MS = 500L
+        /** Pause before re-issuing a stack-rejected discoverServices() (official app: waitFor(1000)). */
+        private const val SERVICE_DISCOVERY_RETRY_MS = 1_000L
+        /** If the onMtuChanged callback never arrives, discover services anyway after this long.
+         *  Comfortably inside CONNECT_TIMEOUT_MS so a stuck MTU exchange still leaves time to sync. */
+        private const val MTU_DISCOVERY_FALLBACK_MS = 3_000L
         /** Unattended reconnect attempts before giving up until user action / app foreground
          *  (official QRing app: maxReconnect = 10). */
         private const val MAX_RECONNECT_ATTEMPTS = 10

--- a/app/src/main/java/com/pulseloop/ui/components/MarkdownLite.kt
+++ b/app/src/main/java/com/pulseloop/ui/components/MarkdownLite.kt
@@ -1,0 +1,100 @@
+package com.pulseloop.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.pulseloop.ui.theme.PulseColors
+
+/**
+ * Minimal markdown renderer shared across the app (coach replies, the "What's new" update
+ * dialog): `## ` headings as semibold lines, `- `/`* `/`• ` bullet lines with accent dots,
+ * `**bold**` inline, `[text](url)` links flattened to their text, and `` `code` `` unwrapped.
+ * Anything else renders as-is. Full markdown (tables, images) is intentionally out of scope —
+ * this exists so release notes and assistant text read cleanly instead of showing raw `#`/`*`.
+ *
+ * Colors default to the fixed dark [PulseColors] palette (correct on the coach's dark cards).
+ * A caller rendering onto a theme-driven surface — e.g. the Material [AlertDialog] update
+ * sheet, which is light in light mode — must pass theme colors so the text stays legible.
+ */
+@Composable
+fun MarkdownLite(
+    text: String,
+    modifier: Modifier = Modifier,
+    headingColor: Color = PulseColors.textPrimary,
+    bodyColor: Color = PulseColors.textSecondary,
+    bulletColor: Color = PulseColors.accent,
+    boldColor: Color = PulseColors.textPrimary,
+) {
+    Column(modifier, verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        text.split("\n").forEach { rawLine ->
+            val line = rawLine.trimEnd()
+            when {
+                line.isBlank() -> Spacer(Modifier.height(2.dp))
+                line.startsWith("#") -> Text(
+                    mdInline(line.trimStart('#', ' '), boldColor),
+                    fontSize = 15.sp, fontWeight = FontWeight.SemiBold, color = headingColor,
+                )
+                line.startsWith("- ") || line.startsWith("* ") || line.startsWith("• ") -> Row {
+                    Box(
+                        Modifier
+                            .padding(top = 7.dp, end = 8.dp)
+                            .size(5.dp)
+                            .clip(CircleShape)
+                            .background(bulletColor),
+                    )
+                    Text(mdInline(line.substring(2), boldColor), fontSize = 14.sp, lineHeight = 20.sp, color = bodyColor)
+                }
+                else -> Text(mdInline(line, boldColor), fontSize = 14.sp, lineHeight = 20.sp, color = bodyColor)
+            }
+        }
+    }
+}
+
+private val LINK_RE = Regex("""\[([^\]]+)]\(([^)]+)\)""")
+private val CODE_RE = Regex("""`([^`]+)`""")
+
+/**
+ * Render one line of inline markdown: flatten `[text](url)` to `text` and unwrap `` `code` ``
+ * first (so their contents can still carry `**bold**`), then bold the `**…**` runs. Bare URLs
+ * are left untouched — dropping them would hide the changelog's "Full Changelog" link target.
+ */
+private fun mdInline(raw: String, boldColor: Color): AnnotatedString {
+    val line = raw
+        .replace(LINK_RE) { it.groupValues[1] }
+        .replace(CODE_RE) { it.groupValues[1] }
+    return buildAnnotatedString {
+        var rest = line
+        while (true) {
+            val start = rest.indexOf("**")
+            val end = if (start >= 0) rest.indexOf("**", start + 2) else -1
+            if (start < 0 || end < 0) {
+                append(rest)
+                return@buildAnnotatedString
+            }
+            append(rest.substring(0, start))
+            withStyle(SpanStyle(fontWeight = FontWeight.SemiBold, color = boldColor)) {
+                append(rest.substring(start + 2, end))
+            }
+            rest = rest.substring(end + 2)
+        }
+    }
+}

--- a/app/src/main/java/com/pulseloop/ui/screens/CoachScreen.kt
+++ b/app/src/main/java/com/pulseloop/ui/screens/CoachScreen.kt
@@ -32,16 +32,13 @@ import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.text.AnnotatedString
-import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.buildAnnotatedString
-import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.pulseloop.coach.attachments.CoachAttachmentRef
 import kotlinx.coroutines.launch
 import com.pulseloop.coach.attachments.CoachAttachmentStore
+import com.pulseloop.ui.components.MarkdownLite
 import com.pulseloop.ui.theme.PulseColors
 import com.pulseloop.ui.viewmodels.CoachViewModel
 
@@ -195,55 +192,6 @@ private fun MessageBubble(msg: CoachViewModel.ChatMessage) {
                 }
             }
         }
-    }
-}
-
-/**
- * Minimal markdown for assistant replies: `**bold**` inline, `- `/`* ` bullet lines with purple
- * dots, `## ` headings as semibold lines. Full rendering (tables, inline charts) is a follow-up.
- */
-@Composable
-private fun MarkdownLite(text: String) {
-    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-        text.split("\n").forEach { rawLine ->
-            val line = rawLine.trimEnd()
-            when {
-                line.isBlank() -> Spacer(Modifier.height(2.dp))
-                line.startsWith("#") -> Text(
-                    line.trimStart('#', ' '),
-                    fontSize = 15.sp, fontWeight = FontWeight.SemiBold, color = PulseColors.textPrimary,
-                )
-                line.startsWith("- ") || line.startsWith("* ") || line.startsWith("• ") -> Row {
-                    Box(
-                        Modifier
-                            .padding(top = 7.dp, end = 8.dp)
-                            .size(5.dp)
-                            .clip(CircleShape)
-                            .background(PulseColors.accent),
-                    )
-                    Text(boldSpans(line.substring(2)), fontSize = 14.sp, lineHeight = 20.sp, color = PulseColors.textSecondary)
-                }
-                else -> Text(boldSpans(line), fontSize = 14.sp, lineHeight = 20.sp, color = PulseColors.textSecondary)
-            }
-        }
-    }
-}
-
-/** Renders `**bold**` runs semibold in the primary text color. */
-private fun boldSpans(line: String): AnnotatedString = buildAnnotatedString {
-    var rest = line
-    while (true) {
-        val start = rest.indexOf("**")
-        val end = if (start >= 0) rest.indexOf("**", start + 2) else -1
-        if (start < 0 || end < 0) {
-            append(rest)
-            return@buildAnnotatedString
-        }
-        append(rest.substring(0, start))
-        withStyle(SpanStyle(fontWeight = FontWeight.SemiBold, color = PulseColors.textPrimary)) {
-            append(rest.substring(start + 2, end))
-        }
-        rest = rest.substring(end + 2)
     }
 }
 

--- a/app/src/main/java/com/pulseloop/update/UpdateUi.kt
+++ b/app/src/main/java/com/pulseloop/update/UpdateUi.kt
@@ -4,6 +4,9 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
@@ -15,6 +18,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import com.pulseloop.BuildConfig
+import com.pulseloop.ui.components.MarkdownLite
 import kotlinx.coroutines.launch
 
 /**
@@ -39,7 +43,19 @@ fun UpdateDialog(info: UpdateInfo, onDismiss: () -> Unit) {
                     Spacer(Modifier.height(8.dp))
                     LinearProgressIndicator(progress = { progress }, modifier = Modifier.fillMaxWidth())
                 } else {
-                    Text(info.changelog, style = MaterialTheme.typography.bodySmall)
+                    MarkdownLite(
+                        info.changelog,
+                        modifier = Modifier
+                            .heightIn(max = 320.dp)
+                            .verticalScroll(rememberScrollState()),
+                        // Theme colors — the dialog surface follows light/dark, unlike the
+                        // coach's fixed dark cards, so the fixed PulseColors defaults would
+                        // be near-invisible on a light dialog.
+                        headingColor = MaterialTheme.colorScheme.onSurface,
+                        bodyColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                        bulletColor = MaterialTheme.colorScheme.primary,
+                        boldColor = MaterialTheme.colorScheme.onSurface,
+                    )
                     error?.let {
                         Spacer(Modifier.height(8.dp))
                         Text(it, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.error)


### PR DESCRIPTION
## Problem

Fixes #18 — jring 56ff can't pair ("Connecting…" forever), while the official Jring app connects fine.

The diagnostic log ([pulseloop-diagnostics-2026-07-10](../issues/18)) shows the ring **connects at the GATT level** — 2M PHY negotiated, MTU negotiated to 512 (`onConfigureMTU mtu=512 status=0`) — but service discovery **never runs** (no `I/RingBLEClient Services:` line ever), so `CONNECTED` is never reached and the 30s watchdog tears the link down (`Connect attempt hung >30000ms`).

## Root cause

Android permits **one outstanding GATT operation at a time**. `onConnectionStateChange` fired `requestMtu(512)` and `discoverServices()` back-to-back, so `discoverServices()` was issued while the MTU exchange was still in flight and got **silently rejected** (returns `false`, dropped). The MTU exchange then completed fine, but `onMtuChanged` was a no-op, so discovery was never retried.

This is the same **"one outstanding GATT op"** class as the R10 op-queue fix (f4e1b3f), but at the **connect handshake**, which bypasses that queue (no `writeChar` exists yet). The official Jring app (`BleBaseControl`) never overlaps these — it settles ~500 ms, discovers, and issues no MTU request. iOS/CoreBluetooth serializes GATT ops for free and exposes no `requestMtu`, so iOS was never affected.

## Fix

- Kick off `discoverServices()` from **`onMtuChanged`** (the op slot is free) instead of overlapping it with `requestMtu()`.
- One-shot `serviceDiscoveryStarted` guard so discovery runs exactly once.
- **Fallbacks so it can't hang:** if `requestMtu()` is rejected outright → discover immediately; if the MTU callback never arrives → a 3 s fallback discovers anyway (well inside the 30 s timeout).
- A 500 ms settle + one retry after 1000 ms on a rejected `discoverServices()`, mirroring the official app.
- Kept `requestMtu(512)` (sequenced, not dropped) so Colmi history-sync keeps the larger MTU.

## Scope / audit

`RingBLEClient` is the **single device-agnostic BLE path** — Jring and Colmi share the same `gattCallback`, so this covers all rings. Audited every other raw GATT op call site: post-discovery reads/writes/CCCD go through the FIFO op-queue, bonding is gated on `awaitOpsFlushed()`, and `requestConnectionPriority`/`setCharacteristicNotification` are non-ATT/local. Nothing else needs the treatment.

## Testing

- Compiles clean (`:app:compileReleaseKotlin`).
- ⚠️ Not yet verified on-device on the realme/Android 16 stack from the report — verified by static analysis against the log + the official app's sequencing. Confirming signal for a test build: an `I/RingBLEClient Services:` line appearing in logcat shortly after `onConfigureMTU`.
