### PR TITLE
fix(colmi+coach): decouple sleep + harden GATT write queue + surface coach errors

### DIFF
--- a/app/src/main/java/com/pulseloop/coach/openai/OpenAIResponsesClient.kt
+++ b/app/src/main/java/com/pulseloop/coach/openai/OpenAIResponsesClient.kt
@@ -176,6 +176,22 @@ object OpenAIRequestBuilder {
     fun reasoningParams(effort: String?): Map<String, JsonElement> =
         if (effort.isNullOrBlank()) emptyMap()
         else mapOf("reasoning" to JsonObject(mapOf("effort" to JsonPrimitive(effort))))
+
+    /**
+     * Model-aware form: also drops `reasoning` for models that don't support it. OpenAI's legacy
+     * chat models (gpt-4o, gpt-4, gpt-3.5, chatgpt-*) reject any request carrying `reasoning` with
+     * an HTTP 400 — which, combined with the un-gated Settings combo (a non-reasoning model + a set
+     * effort), failed *every* coach turn and showed the user one identical fallback. We default to
+     * ALLOWING reasoning so unknown/future models aren't blocked, and suppress only the known
+     * non-reasoning families. The OpenRouter `vendor/model` prefix is stripped before matching.
+     */
+    fun reasoningParams(effort: String?, model: String): Map<String, JsonElement> =
+        if (!modelSupportsReasoning(model)) emptyMap() else reasoningParams(effort)
+
+    private fun modelSupportsReasoning(model: String): Boolean {
+        val slug = model.lowercase().substringAfterLast('/')  // strip OpenRouter vendor prefix
+        return !(slug.startsWith("gpt-4") || slug.startsWith("gpt-3") || slug.startsWith("chatgpt"))
+    }
 }
 
 /**

--- a/app/src/main/java/com/pulseloop/coach/orchestration/CoachOrchestrator.kt
+++ b/app/src/main/java/com/pulseloop/coach/orchestration/CoachOrchestrator.kt
@@ -196,8 +196,9 @@ class CoachOrchestrator(
         textFormat: JsonObject,
         previousResponseId: String?,
     ): com.pulseloop.coach.openai.OpenAIResponse {
-        // Optional reasoning-effort hint (mirrors iOS OpenAIRequestBuilder).
-        val reasoning = OpenAIRequestBuilder.reasoningParams(flags.settings.reasoningEffort)
+        // Optional reasoning-effort hint (mirrors iOS OpenAIRequestBuilder). Gated by model so a
+        // non-reasoning model (e.g. gpt-4o) doesn't get a `reasoning` field it would reject.
+        val reasoning = OpenAIRequestBuilder.reasoningParams(flags.settings.reasoningEffort, flags.model)
         val body = JsonObject(mapOf(
             "model" to JsonPrimitive(flags.model),
             "input" to JsonArray(input),

--- a/app/src/main/java/com/pulseloop/coach/summaries/CoachSummaryGenerator.kt
+++ b/app/src/main/java/com/pulseloop/coach/summaries/CoachSummaryGenerator.kt
@@ -45,7 +45,7 @@ object CoachSummaryGenerator {
                 "model" to JsonPrimitive(flags.model),
                 "input" to input,
                 "text" to textFormat,
-            ) + OpenAIRequestBuilder.reasoningParams(flags.settings.reasoningEffort))
+            ) + OpenAIRequestBuilder.reasoningParams(flags.settings.reasoningEffort, flags.model))
             val resolved = client ?: OpenAIResponsesClient(apiKey)
             val bodyBytes = Json.encodeToString(JsonObject.serializer(), body).toByteArray()
             val response = resolved.send(bodyBytes)

--- a/app/src/main/java/com/pulseloop/ring/ColmiSyncEngine.kt
+++ b/app/src/main/java/com/pulseloop/ring/ColmiSyncEngine.kt
@@ -256,6 +256,12 @@ class ColmiSyncEngine(
                     sleepOnlyWatchdogJob?.cancel(); sleepOnlyWatchdogJob = null
                     return
                 }
+                // Only the pipeline's own SLEEP stage should advance to HRV. Ignore a stray sleep
+                // completion that arrives when we're not on SLEEP — e.g. a standalone reply that
+                // landed after a full sync started (startHistorySync cleared sleepOnlyActive), or a
+                // late reply after the watchdog already skipped SLEEP. Otherwise it jumps/duplicates
+                // the pipeline (ACTIVITY→HRV, skipping HR/STRESS/SPO2, or a second HRV request).
+                if (stage != Stage.SLEEP) return
                 stage = Stage.HRV; daysAgo = 0; requestHRV(); armWatchdog()
             }
             ColmiCommandID.BIG_DATA_TEMPERATURE -> {

--- a/app/src/main/java/com/pulseloop/ring/ColmiSyncEngine.kt
+++ b/app/src/main/java/com/pulseloop/ring/ColmiSyncEngine.kt
@@ -49,6 +49,12 @@ class ColmiSyncEngine(
     private var daysAgo = 0
     private var syncDay = LocalDate.now(zone)
 
+    /** A standalone sleep-only request is outstanding (see [syncSleepNow]). Set true when we fire
+     *  `bigDataSleep()` outside the staged history sync; its big-data completion clears it and
+     *  must NOT advance the pipeline into HRV. Volatile: set on Main, read on the notify thread. */
+    @Volatile private var sleepOnlyActive = false
+    private var sleepOnlyWatchdogJob: Job? = null
+
     // Watchdog
     private var watchdogJob: Job? = null
     private val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
@@ -103,6 +109,26 @@ class ColmiSyncEngine(
             writer?.enqueue(encoder.writePref(ColmiCommandID.AUTO_HRV_PREF, enabled = true))
         }
         startHistorySync()
+    }
+
+    /**
+     * On-demand sleep fetch (QRing parity): request just the sleep big-data record, off the
+     * staged history pipeline, so it can't be lost to an earlier stage's watchdog skip. The
+     * decoder emits sleep events from the reply exactly as it does during a full sync; the only
+     * difference is [handleBigDataComplete] must not advance into HRV afterwards
+     * ([sleepOnlyActive]). If a full history sync is already running it will fetch sleep itself,
+     * so this becomes a no-op then.
+     */
+    override fun syncSleepNow() {
+        if (sleepOnlyActive) return  // one already outstanding — don't double-request
+        if (stage != Stage.IDLE && stage != Stage.DONE) return  // a full sync already covers sleep
+        sleepOnlyActive = true
+        requestSleep()
+        sleepOnlyWatchdogJob?.cancel()
+        sleepOnlyWatchdogJob = scope.launch {
+            delay(watchdogTimeoutMs)
+            sleepOnlyActive = false  // reply never completed — give up quietly, no pipeline advance
+        }
     }
 
     // MARK: Measurement settings + user profile (iOS #19)
@@ -196,6 +222,10 @@ class ColmiSyncEngine(
     }
 
     private fun startHistorySync() {
+        // A full sync fetches sleep itself; cancel any standalone sleep-only request so its
+        // big-data completion doesn't short-circuit the pipeline's own SLEEP stage.
+        sleepOnlyActive = false
+        sleepOnlyWatchdogJob?.cancel(); sleepOnlyWatchdogJob = null
         daysAgo = 0
         stage = Stage.ACTIVITY
         requestActivity()
@@ -219,6 +249,13 @@ class ColmiSyncEngine(
                 stage = Stage.SLEEP; requestSleep(); armWatchdog()
             }
             ColmiCommandID.BIG_DATA_SLEEP -> {
+                // A standalone sleep-only fetch just completed: the decoder already emitted the
+                // sleep events; do NOT drive the full-sync pipeline into HRV.
+                if (sleepOnlyActive) {
+                    sleepOnlyActive = false
+                    sleepOnlyWatchdogJob?.cancel(); sleepOnlyWatchdogJob = null
+                    return
+                }
                 stage = Stage.HRV; daysAgo = 0; requestHRV(); armWatchdog()
             }
             ColmiCommandID.BIG_DATA_TEMPERATURE -> {

--- a/app/src/main/java/com/pulseloop/ring/RingBLEClient.kt
+++ b/app/src/main/java/com/pulseloop/ring/RingBLEClient.kt
@@ -146,6 +146,13 @@ class RingBLEClient(private val context: Context) {
     private val opQueue = ArrayDeque<GattOp>()
     private var inFlightOp: GattOp? = null
 
+    // Consecutive GATT ops that failed to issue (writeCharacteristic == false) or never got a
+    // completion callback. A run of these means the framework's single-operation slot is wedged
+    // — retrying into it just spins — so once the run crosses OP_FAILURE_RECONNECT_THRESHOLD we
+    // force a reconnect, the only thing that clears mDeviceBusy. Reset on any successful
+    // completion. Guarded by opLock. See docs/colmi-sleep-sync-diagnosis.md.
+    private var consecutiveOpFailures = 0
+
     // MARK: Connection state
 
     private val scope = CoroutineScope(Dispatchers.Main + SupervisorJob())
@@ -715,6 +722,42 @@ class RingBLEClient(private val context: Context) {
         }
     }
 
+    /** A log label that survives R8 minification (release logs showed only the obfuscated "J").
+     *  For a command write it embeds the command byte, so a dropped sleep request reads
+     *  `cmd:0x27` instead of an opaque class name. */
+    private fun opLabel(op: GattOp): String = when (op) {
+        is GattOp.CommandWrite -> "cmd:0x%02x".format(if (op.data.isNotEmpty()) op.data[0].toInt() and 0xFF else 0)
+        is GattOp.Read -> "read"
+        is GattOp.DescriptorWrite -> "cccd"
+    }
+
+    /** Record a dropped/timed-out op and, if the run of failures means the GATT slot is wedged,
+     *  kick a reconnect. Returns true when recovery was triggered — the caller must then stop
+     *  pumping, since the queue is being torn down. */
+    private fun noteOpFailureAndMaybeRecover(): Boolean {
+        val wedged = synchronized(opLock) {
+            consecutiveOpFailures++
+            if (consecutiveOpFailures >= OP_FAILURE_RECONNECT_THRESHOLD) {
+                consecutiveOpFailures = 0  // reset in-lock so a concurrent failure can't re-trigger
+                true
+            } else false
+        }
+        if (wedged) recoverWedgedLink()
+        return wedged
+    }
+
+    /** Clear the failure run after any successful GATT completion (the stack is responsive). */
+    private fun resetOpFailures() = synchronized(opLock) { consecutiveOpFailures = 0 }
+
+    /** The single-op slot is wedged: drop the queue and reconnect from scratch to clear the
+     *  Android stack's stuck busy flag, instead of endlessly dropping commands into it. Mirrors
+     *  the official SDKs, which reset the link on terminal write failure. */
+    private fun recoverWedgedLink() {
+        Log.w("RingBLEClient", "GATT op slot wedged — forcing reconnect to clear it")
+        resetOpQueue()
+        scope.launch { forceReconnect() }
+    }
+
     private fun pumpOps() {
         while (true) {
             val gatt = bluetoothGatt ?: return
@@ -738,10 +781,15 @@ class RingBLEClient(private val context: Context) {
                     } else {
                         val target = if (op.useCommandChannel) commandChar ?: wChar else wChar
                         target.value = op.data
-                        PulseEventBus.publishBlocking(
-                            PulseEvent.RawPacket(PacketDirection.OUTGOING, op.data,
-                                RingDecodedEvent.CommandAck(commandId = if (op.data.isNotEmpty()) op.data[0].toUByte() else 0u))
-                        )
+                        // Publish the outgoing packet once, on the first issue attempt only — a
+                        // retry storm used to log 200 duplicate CommandAcks, flooding the 200-entry
+                        // diagnostics ring buffer and evicting the real reply packets.
+                        if (op.attempts == 0) {
+                            PulseEventBus.publishBlocking(
+                                PulseEvent.RawPacket(PacketDirection.OUTGOING, op.data,
+                                    RingDecodedEvent.CommandAck(commandId = if (op.data.isNotEmpty()) op.data[0].toUByte() else 0u))
+                            )
+                        }
                         gatt.writeCharacteristic(target)
                     }
                 }
@@ -760,7 +808,11 @@ class RingBLEClient(private val context: Context) {
                 scope.launch {
                     delay(OP_TIMEOUT_MS)
                     if (inFlightOp === op) {
-                        Log.w("RingBLEClient", "GATT op ACK timed out — unblocking queue")
+                        Log.w("RingBLEClient", "GATT op ACK timed out — unblocking queue: ${opLabel(op)}")
+                        // A lost completion callback leaves the framework slot busy: don't just
+                        // free our slot and pump the next op into a still-busy stack (that is the
+                        // spin-and-drop loop). Escalate to a reconnect once enough pile up.
+                        if (noteOpFailureAndMaybeRecover()) return@launch
                         completeOp { it === op }  // never retire a successor issued meanwhile
                     }
                 }
@@ -775,14 +827,17 @@ class RingBLEClient(private val context: Context) {
             if (op.attempts < MAX_OP_ATTEMPTS - 1) {
                 op.attempts++
                 synchronized(opLock) { opQueue.addFirst(op) }
-                Log.w("RingBLEClient", "GATT op rejected at issue — retrying: ${op::class.simpleName}")
+                Log.w("RingBLEClient", "GATT op rejected at issue — retrying (${op.attempts}/$MAX_OP_ATTEMPTS): ${opLabel(op)}")
                 scope.launch {
                     delay(OP_RETRY_DELAY_MS)
                     pumpOps()
                 }
                 return
             }
-            Log.w("RingBLEClient", "GATT op dropped after $MAX_OP_ATTEMPTS attempts: ${op::class.simpleName}")
+            Log.w("RingBLEClient", "GATT op dropped after $MAX_OP_ATTEMPTS attempts: ${opLabel(op)}")
+            // The slot may be wedged — escalate to a reconnect rather than pump the next op into
+            // the same busy stack (the tear-down aborts the loop).
+            if (noteOpFailureAndMaybeRecover()) return
             // Loop on to the next queued op.
         }
     }
@@ -1008,6 +1063,7 @@ class RingBLEClient(private val context: Context) {
         ) {
             if (gatt !== bluetoothGatt) return  // late callback from a superseded connection
             lastActivityAt = System.currentTimeMillis()  // GATT read completed — link is alive
+            resetOpFailures()
             // Retire the in-flight op regardless of payload, before any early return —
             // but only if it IS the read this callback answers (a stale post-timeout ACK
             // must not retire the op that was issued after it).
@@ -1036,6 +1092,7 @@ class RingBLEClient(private val context: Context) {
         ) {
             if (gatt !== bluetoothGatt) return  // late callback from a superseded connection
             lastActivityAt = System.currentTimeMillis()  // GATT ACK — link is alive
+            resetOpFailures()  // a real completion — the stack is responsive again
             completeOp { it is GattOp.CommandWrite }
         }
 
@@ -1099,6 +1156,7 @@ class RingBLEClient(private val context: Context) {
         ) {
             if (gatt !== bluetoothGatt) return  // late callback from a superseded connection
             lastActivityAt = System.currentTimeMillis()  // descriptor ACK — link is alive
+            resetOpFailures()
             // Retire the in-flight op before any early return, so the queue drains.
             completeOp { it is GattOp.DescriptorWrite && it.descriptor === descriptor }
 
@@ -1261,10 +1319,18 @@ class RingBLEClient(private val context: Context) {
         /** Max wait for any GATT op's completion callback before unblocking the queue
          *  (prevents a stuck in-flight op stranding every subsequent operation). */
         private const val OP_TIMEOUT_MS = 4_000L
-        /** Total issue attempts for an op the stack rejects before it is dropped. */
-        private const val MAX_OP_ATTEMPTS = 3
+        /** Total issue attempts for an op the stack rejects before it is dropped. The official
+         *  QRing/JRing SDKs retry a rejected write persistently (JRing: up to ~30×) rather than
+         *  giving up after a few — a slow/high-latency link (the R10 negotiated interval=99,
+         *  latency=4) can leave the single-op slot briefly busy across several attempts. */
+        private const val MAX_OP_ATTEMPTS = 6
         /** Pause before re-issuing a stack-rejected op (lets a transient busy state clear). */
-        private const val OP_RETRY_DELAY_MS = 150L
+        private const val OP_RETRY_DELAY_MS = 200L
+        /** Consecutive dropped/timed-out ops that mean the framework's single-op slot is wedged
+         *  (mDeviceBusy stuck true after a lost completion callback). Retrying into it only spins,
+         *  so we force a reconnect — the one thing that clears the flag — instead of silently
+         *  dropping commands (which is how the sleep/history request went missing on the R10). */
+        private const val OP_FAILURE_RECONNECT_THRESHOLD = 3
         /** Default bound for [awaitOpsFlushed]. */
         private const val OPS_FLUSH_TIMEOUT_MS = 10_000L
         /** Max wait for the ring's UNBOND_ACK after a forget before forcing teardown. */

--- a/app/src/main/java/com/pulseloop/ring/WearableDriver.kt
+++ b/app/src/main/java/com/pulseloop/ring/WearableDriver.kt
@@ -94,6 +94,13 @@ data class UserProfileValues(
 interface RingSyncEngine {
     fun runStartup()
     fun handle(event: RingDecodedEvent)
+
+    /** On-demand, standalone sleep fetch — request just the sleep record without running the
+     *  whole history pipeline (which buries sleep behind activity/HR/stress/SpO₂ and can lose it
+     *  to a watchdog stage-skip). Mirrors the official QRing app, which fires a dedicated sleep
+     *  request when its sleep screen opens. No-op on devices whose history sync isn't staged this
+     *  way (jring fetches sleep in one bulk history request, so it has nothing to decouple). */
+    fun syncSleepNow() {}
     fun startHeartRate()
     fun stopHeartRate()
     fun measureHeartRateSpot() { startHeartRate() }

--- a/app/src/main/java/com/pulseloop/service/RingSyncCoordinator.kt
+++ b/app/src/main/java/com/pulseloop/service/RingSyncCoordinator.kt
@@ -208,6 +208,18 @@ class RingSyncCoordinator(
         runStartupSequence()
     }
 
+    /**
+     * On-demand, sleep-only sync (QRing-style): fetch just the sleep record without running the
+     * whole history pipeline. Wired to the Sleep screen opening so a user who wants last night's
+     * sleep gets a dedicated request instead of depending on the full sync's SLEEP stage
+     * surviving four earlier stages. No-op when disconnected, or on rings that fetch sleep in
+     * bulk (jring).
+     */
+    fun syncSleepNow() {
+        if (!isConnected) return
+        engine?.syncSleepNow()
+    }
+
     /** Pull-to-refresh entry point. */
     suspend fun pullToRefresh() {
         if (isConnected) {

--- a/app/src/main/java/com/pulseloop/ui/PulseLoopApp.kt
+++ b/app/src/main/java/com/pulseloop/ui/PulseLoopApp.kt
@@ -379,7 +379,7 @@ fun PulseLoopApp() {
             ) {
                 composable("today") { TodayScreen(navController, todayVM, coordinator, vitalsVM, sleepVM, topBarPadding = topPad, bottomBarPadding = barPad) }
                 composable("vitals") { VitalsScreen(navController = navController, viewModel = vitalsVM, coordinator = coordinator, topBarPadding = topPad, bottomBarPadding = barPad) }
-                composable("sleep") { SleepScreen(navController = navController, viewModel = sleepVM, topBarPadding = topPad, bottomBarPadding = barPad) }
+                composable("sleep") { SleepScreen(navController = navController, viewModel = sleepVM, onOpen = { coordinator.syncSleepNow() }, topBarPadding = topPad, bottomBarPadding = barPad) }
                 composable("activity") { ActivityScreen(navController = navController, viewModel = activityVM, liveWorkout = liveWorkout, topBarPadding = topPad, bottomBarPadding = barPad) }
                 paddedComposable("activity_detail/{id}") { backStackEntry ->
                     val id = backStackEntry.arguments?.getString("id") ?: return@paddedComposable

--- a/app/src/main/java/com/pulseloop/ui/screens/CoachScreen.kt
+++ b/app/src/main/java/com/pulseloop/ui/screens/CoachScreen.kt
@@ -161,11 +161,19 @@ private fun MessageBubble(msg: CoachViewModel.ChatMessage) {
         Modifier.fillMaxWidth(),
         horizontalAlignment = if (isUser) Alignment.End else Alignment.Start,
     ) {
+        val errorColor = Color(0xFFF87171)
         Column(
             Modifier
                 .widthIn(max = if (isUser) 300.dp else 360.dp)
                 .clip(RoundedCornerShape(24.dp))
-                .background(if (isUser) PulseColors.accent else PulseColors.card)
+                .background(
+                    when {
+                        isUser -> PulseColors.accent
+                        msg.isError -> errorColor.copy(alpha = 0.12f)
+                        else -> PulseColors.card
+                    }
+                )
+                .then(if (msg.isError) Modifier.border(1.dp, errorColor.copy(alpha = 0.5f), RoundedCornerShape(24.dp)) else Modifier)
                 .padding(horizontal = 16.dp, vertical = 12.dp),
             verticalArrangement = Arrangement.spacedBy(6.dp),
         ) {
@@ -185,10 +193,10 @@ private fun MessageBubble(msg: CoachViewModel.ChatMessage) {
                 }
             }
             if (msg.text.isNotBlank()) {
-                if (isUser) {
-                    Text(msg.text, fontSize = 14.sp, lineHeight = 20.sp, color = Color.White)
-                } else {
-                    MarkdownLite(msg.text)
+                when {
+                    isUser -> Text(msg.text, fontSize = 14.sp, lineHeight = 20.sp, color = Color.White)
+                    msg.isError -> Text(msg.text, fontSize = 14.sp, lineHeight = 20.sp, color = errorColor)
+                    else -> MarkdownLite(msg.text)
                 }
             }
         }

--- a/app/src/main/java/com/pulseloop/ui/screens/SleepScreen.kt
+++ b/app/src/main/java/com/pulseloop/ui/screens/SleepScreen.kt
@@ -42,10 +42,15 @@ import com.pulseloop.ui.viewmodels.SleepViewModel
 fun SleepScreen(
     navController: androidx.navigation.NavController? = null,
     viewModel: SleepViewModel? = null,
+    // Invoked once when the screen opens: triggers a dedicated on-demand sleep sync (QRing
+    // parity) so opening this screen actively pulls last night's sleep instead of relying on
+    // the background full-sync's SLEEP stage. No-op when disconnected / unsupported.
+    onOpen: () -> Unit = {},
     // Heights of the glass top/bottom bars this screen scrolls under (0 when standalone).
     topBarPadding: androidx.compose.ui.unit.Dp = 0.dp,
     bottomBarPadding: androidx.compose.ui.unit.Dp = 0.dp,
 ) {
+    LaunchedEffect(Unit) { onOpen() }
     val state by (viewModel?.state?.collectAsState() ?: remember { mutableStateOf(SleepViewModel.SleepState()) })
 
     LazyColumn(

--- a/app/src/main/java/com/pulseloop/ui/viewmodels/ViewModels.kt
+++ b/app/src/main/java/com/pulseloop/ui/viewmodels/ViewModels.kt
@@ -646,10 +646,13 @@ class CoachViewModel(
                 } else {
                     ChatMessage("assistant", result.assistant.plainText)
                 }
+                // The red error bubble (above) already carries the code + reason; don't also set
+                // `error`, or CoachScreen renders a duplicate "Error: <code>" footer for the same
+                // failure. `error` stays null here and is reserved for the catch-block path below,
+                // which shows a plain (non-error-bubble) apology and needs the footer.
                 _state.update { it.copy(
                     messages = it.messages + reply,
                     isThinking = false,
-                    error = turnError?.code,
                 ) }
             } catch (e: Exception) {
                 _state.update { it.copy(

--- a/app/src/main/java/com/pulseloop/ui/viewmodels/ViewModels.kt
+++ b/app/src/main/java/com/pulseloop/ui/viewmodels/ViewModels.kt
@@ -618,7 +618,10 @@ class CoachViewModel(
         viewModelScope.launch {
             try {
                 val packet = com.pulseloop.coach.context.CoachContextBuilder.build(db)
-                val prior = _state.value.messages.dropLast(1)
+                // Drop error bubbles: they're app-generated diagnostics (a provider HTTP error),
+                // not real assistant turns. Replaying them as assistant history would feed the
+                // model garbage like "Coach error · HTTP 404 …" as if it had said it.
+                val prior = _state.value.messages.dropLast(1).filter { !it.isError }
                 // Replay images only on the most recent prior user turn that has attachments,
                 // keeping context coherent without ballooning payloads with old base64.
                 val lastAttached = prior.indexOfLast { it.role == "user" && it.attachments.isNotEmpty() }

--- a/app/src/main/java/com/pulseloop/ui/viewmodels/ViewModels.kt
+++ b/app/src/main/java/com/pulseloop/ui/viewmodels/ViewModels.kt
@@ -588,6 +588,9 @@ class CoachViewModel(
         val text: String,
         /** Image attachments on a user turn (iOS #31); thumbnails render from the stored files. */
         val attachments: List<com.pulseloop.coach.attachments.CoachAttachmentRef> = emptyList(),
+        /** A failed turn — render as a distinct error bubble showing the real provider error
+         *  (code + reason) instead of the generic fallback. See [sendMessage]. */
+        val isError: Boolean = false,
     )
 
     private val _state = MutableStateFlow(CoachState(
@@ -629,9 +632,21 @@ class CoachViewModel(
                     userText, packet, priorMessages,
                     userImages = attachmentPayloads(attachments),
                 )
+                // A failed turn returns a FIXED fallback string in `result.assistant`; showing
+                // only that made every failing question look like "the same answer every time"
+                // and hid the real cause (e.g. a model the key can't access, or a `reasoning`
+                // field a non-reasoning model rejects). Surface `result.error` instead so the
+                // user sees the actual provider code + reason and can act on it.
+                val turnError = result.error
+                val reply = if (turnError != null) {
+                    ChatMessage("assistant", turnError.plainText, isError = true)
+                } else {
+                    ChatMessage("assistant", result.assistant.plainText)
+                }
                 _state.update { it.copy(
-                    messages = it.messages + ChatMessage("assistant", result.assistant.plainText),
+                    messages = it.messages + reply,
                     isThinking = false,
+                    error = turnError?.code,
                 ) }
             } catch (e: Exception) {
                 _state.update { it.copy(

--- a/app/src/test/java/com/pulseloop/coach/OpenAIRequestBuilderTest.kt
+++ b/app/src/test/java/com/pulseloop/coach/OpenAIRequestBuilderTest.kt
@@ -58,4 +58,26 @@ class OpenAIRequestBuilderTest {
         assertEquals(setOf("reasoning"), params.keys)
         assertEquals("medium", params["reasoning"]!!.jsonObject["effort"]!!.jsonPrimitive.content)
     }
+
+    @Test
+    fun testReasoningGatedForNonReasoningModels() {
+        // A set effort must NOT be sent to models that reject `reasoning` — the ungated combo
+        // (non-reasoning model + effort) otherwise fails every coach turn (issue #19).
+        assertTrue(OpenAIRequestBuilder.reasoningParams("high", "gpt-4o").isEmpty())
+        assertTrue(OpenAIRequestBuilder.reasoningParams("high", "gpt-4o-mini").isEmpty())
+        assertTrue(OpenAIRequestBuilder.reasoningParams("medium", "gpt-3.5-turbo").isEmpty())
+        assertTrue(OpenAIRequestBuilder.reasoningParams("low", "chatgpt-4o-latest").isEmpty())
+        // OpenRouter vendor prefix is stripped before matching.
+        assertTrue(OpenAIRequestBuilder.reasoningParams("high", "openai/gpt-4o").isEmpty())
+    }
+
+    @Test
+    fun testReasoningAllowedForReasoningModels() {
+        // Reasoning models (and unknown/future slugs) still carry the effort when set.
+        assertEquals("high", OpenAIRequestBuilder.reasoningParams("high", "gpt-5.4")["reasoning"]!!.jsonObject["effort"]!!.jsonPrimitive.content)
+        assertEquals(setOf("reasoning"), OpenAIRequestBuilder.reasoningParams("medium", "gpt-5.5").keys)
+        assertEquals(setOf("reasoning"), OpenAIRequestBuilder.reasoningParams("low", "o3-mini").keys)
+        // Null effort is still omitted regardless of model.
+        assertTrue(OpenAIRequestBuilder.reasoningParams(null, "gpt-5.4").isEmpty())
+    }
 }

--- a/app/src/test/java/com/pulseloop/ring/ColmiSleepSyncTest.kt
+++ b/app/src/test/java/com/pulseloop/ring/ColmiSleepSyncTest.kt
@@ -63,12 +63,29 @@ class ColmiSleepSyncTest {
         val writer = RecordingWriter()
         val engine = ColmiSyncEngine(writer, ColmiDecoder)
         engine.runStartup()               // sleepOnlyActive stays false; stage in pipeline
-        val countAfterStartup = writer.commands.size
+        engine.handleBigDataComplete(ColmiCommandID.BIG_DATA_SPO2)   // drive the pipeline onto SLEEP
+        val countAfterSleepRequest = writer.commands.size
 
         engine.handleBigDataComplete(ColmiCommandID.BIG_DATA_SLEEP)  // normal pipeline sleep→hrv
 
         assertTrue("HRV request should be enqueued after in-pipeline sleep",
-            writer.commands.size > countAfterStartup)
+            writer.commands.size > countAfterSleepRequest)
+        engine.destroy()
+    }
+
+    @Test
+    fun `a stray sleep completion off the SLEEP stage does not jump the pipeline`() {
+        val writer = RecordingWriter()
+        val engine = ColmiSyncEngine(writer, ColmiDecoder)
+        engine.runStartup()               // stage = ACTIVITY, sleepOnlyActive = false
+        val countAfterStartup = writer.commands.size
+
+        // A standalone sleep reply that landed after a full sync started (or a late reply after the
+        // watchdog skipped SLEEP): must NOT advance/duplicate the pipeline into HRV.
+        engine.handleBigDataComplete(ColmiCommandID.BIG_DATA_SLEEP)
+
+        assertEquals("stray sleep completion must not enqueue anything",
+            countAfterStartup, writer.commands.size)
         engine.destroy()
     }
 

--- a/app/src/test/java/com/pulseloop/ring/ColmiSleepSyncTest.kt
+++ b/app/src/test/java/com/pulseloop/ring/ColmiSleepSyncTest.kt
@@ -1,0 +1,86 @@
+package com.pulseloop.ring
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * On-demand sleep decoupling (QRing parity). Verifies that [ColmiSyncEngine.syncSleepNow] fires a
+ * standalone `bigDataSleep()` request off the staged history pipeline, and that its completion does
+ * NOT drive the pipeline into the next stage — while the normal in-pipeline sleep completion still
+ * advances to HRV. Pure — a recording writer captures enqueued commands, no hardware.
+ */
+class ColmiSleepSyncTest {
+
+    private class RecordingWriter : RingCommandWriter {
+        val commands = mutableListOf<ByteArray>()
+        override fun enqueue(command: ByteArray) { commands.add(command) }
+    }
+
+    /** `bc 27 01 00 ff 00 ff` — big-data V2 sleep request. */
+    private val sleepRequest = ColmiEncoder.bigDataSleep()
+
+    @Test
+    fun `syncSleepNow from idle fires exactly the standalone sleep request`() {
+        val writer = RecordingWriter()
+        val engine = ColmiSyncEngine(writer, ColmiDecoder)
+
+        engine.syncSleepNow()
+
+        assertEquals("only the sleep request should be enqueued", 1, writer.commands.size)
+        assertArrayEquals(sleepRequest, writer.commands.single())
+        engine.destroy()
+    }
+
+    @Test
+    fun `syncSleepNow is a no-op while a full history sync is running`() {
+        val writer = RecordingWriter()
+        val engine = ColmiSyncEngine(writer, ColmiDecoder)
+        engine.runStartup()               // stage advances into the pipeline (ACTIVITY)
+        val countAfterStartup = writer.commands.size
+
+        engine.syncSleepNow()             // full sync already fetches sleep — must not double-request
+
+        assertEquals(countAfterStartup, writer.commands.size)
+        engine.destroy()
+    }
+
+    @Test
+    fun `standalone sleep completion does not advance the pipeline to HRV`() {
+        val writer = RecordingWriter()
+        val engine = ColmiSyncEngine(writer, ColmiDecoder)
+        engine.syncSleepNow()             // sleepOnlyActive = true, 1 command (sleep)
+
+        engine.handleBigDataComplete(ColmiCommandID.BIG_DATA_SLEEP)
+
+        assertEquals("no follow-up request after a standalone sleep", 1, writer.commands.size)
+        engine.destroy()
+    }
+
+    @Test
+    fun `in-pipeline sleep completion still advances to HRV`() {
+        val writer = RecordingWriter()
+        val engine = ColmiSyncEngine(writer, ColmiDecoder)
+        engine.runStartup()               // sleepOnlyActive stays false; stage in pipeline
+        val countAfterStartup = writer.commands.size
+
+        engine.handleBigDataComplete(ColmiCommandID.BIG_DATA_SLEEP)  // normal pipeline sleep→hrv
+
+        assertTrue("HRV request should be enqueued after in-pipeline sleep",
+            writer.commands.size > countAfterStartup)
+        engine.destroy()
+    }
+
+    @Test
+    fun `syncSleepNow does not double-request while one is already outstanding`() {
+        val writer = RecordingWriter()
+        val engine = ColmiSyncEngine(writer, ColmiDecoder)
+
+        engine.syncSleepNow()
+        engine.syncSleepNow()             // still outstanding — must be ignored
+
+        assertEquals(1, writer.commands.size)
+        engine.destroy()
+    }
+}

--- a/docs/colmi-sleep-sync-diagnosis.md
+++ b/docs/colmi-sleep-sync-diagnosis.md
@@ -1,0 +1,166 @@
+# Colmi sleep sync — why sleep goes missing, and how QRing/iOS differ
+
+Investigation date: 2026-07-10. Trigger: a COLMI R10 (`wearableType=COLMI_R02`,
+firmware `RT03CR_1.00.02_260319`) returned **no sleep log** after a night's wear. Two
+diagnostics captures taken right after waking (`pulseloop-diagnostics-2026-07-10T17-32`,
+`...2026-07-11T01-29`) drove this analysis.
+
+## TL;DR
+
+Sleep is not lost because of anything sleep-specific. It's lost because:
+
+1. **The Android GATT write queue thrashes** — `writeCharacteristic()` returns `false`
+   repeatedly ("device busy"), and our ACK-timeout optimistically frees the queue slot
+   while the framework op is still pending, so we spin-and-drop commands.
+2. **Sleep is buried mid-pipeline.** `ColmiSyncEngine` runs one chained 9-stage history
+   sync (`ACTIVITY→HEART_RATE→STRESS→SPO2→SLEEP→HRV→BP→TEMPERATURE→BLOOD_SUGAR`). Each
+   stage is one write into that failing queue, and a per-stage watchdog **silently
+   force-skips** a stalled stage. When the `bigDataSleep()` request (or its multi-frame
+   reply) is dropped, the watchdog skips `SLEEP→HRV` and no sleep is persisted — no error
+   surfaces to the user.
+
+The request bytes themselves are correct and identical across platforms.
+
+## Evidence from the diagnostics
+
+Both captures show the same failure, mild in the daytime capture and severe post-wake:
+
+```
+W/RingBLEClient: GATT op rejected at issue — retrying: J   (writeCharacteristic() == false)
+W/RingBLEClient: GATT op dropped after 3 attempts: J
+W/RingBLEClient: GATT op ACK timed out — unblocking queue
+```
+
+- Post-wake: hundreds of write rejections + ACK timeouts over ~10 s. Daytime: ~18, then
+  recovered.
+- `"J"` is the R8-obfuscated `GattOp` subclass name in the release build — the log can't
+  even say which op failed. **Diagnostics gap: keep the op label readable in release.**
+- Connection landed at `interval=99 latency=4` (a slow/low-power link, ~124 ms interval,
+  4 skippable events) despite the code requesting `CONNECTION_PRIORITY_HIGH`.
+- `rawPackets` is a 200-entry ring buffer covering only the last ~250 ms; post-wake it was
+  flooded with 200 of our own retry `command_ack`s, evicting any real sleep reply.
+  **Diagnostics gap: retries shouldn't flood the packet buffer.**
+
+## How the sleep request is built (all three are byte-identical)
+
+| Platform | Call | Bytes |
+|---|---|---|
+| Android | `ColmiEncoder.bigDataSleep()` | `bc 27 01 00 ff 00 ff` |
+| iOS | `ColmiEncoder.bigDataSleep()` | `bc 27 01 00 ff 00 ff` |
+| QRing (new protocol) | `LargeDataHandler.syncSleepList(offset)` | big-data cmd 39, `offset` byte |
+
+`bc` = big-data V2, `27` = sleep. The trailing `01 00 ff 00 ff` requests full history.
+
+## Are all Colmi rings handled the same on Android? — Yes, fully uniform
+
+Every Colmi/Yawell model (R02/R03/R06/R07/R09/**R10**/R11/R12, Yawell R05/R10/R11, H59)
+collapses to the single `RingDeviceType.COLMI_R02` family and one `ColmiCoordinator`.
+Model identity is used **only** for display (name/image/brand tab) via advertised-name
+regex. There is:
+
+- No per-model / per-firmware / per-capability branch in `requestSleep()`,
+  `bigDataSleep()`, or `decodeSleep()`.
+- **No capability-gating of any stage** — the ring's reported `sleep,remSleep` capability
+  is never consulted; the device-support bitfield is read only to decide BLE bonding.
+- **No new-vs-old sleep-protocol concept at all** (zero matches for `newSleep`/
+  `sleepProtocol`). One path only: big-data V2 `0x27`.
+
+So the R10 is treated byte-for-byte like a working R02. The only model/firmware-sensitive
+Colmi code anywhere is the auto-HR record shape (`ColmiEncoder.autoHeartRate`), unrelated
+to sleep.
+
+## How the official QRing app does it — per-ring, decoupled, two channels
+
+QRing (Oudmon/Realsil `bbpro` SDK, `SleepDetailRepository.java`) differs in three ways
+that matter:
+
+1. **Per-ring protocol selection.** A single boolean `UserConfig.newSleepProtocol`
+   selects between two uniform sleep protocols. It is set from a **capability bit the ring
+   declares about itself** — `SetTimeRsp` byte[8] (returned to `SetTimeReq(1)` at connect),
+   persisted once and read by every sleep path. New → big-data `syncSleepList`; old →
+   day-indexed `ReadSleepDetailsReq(dayIndex, 0, 95)`. No model lookup table.
+2. **Sleep is an independent, on-demand request** — fired directly when the sleep screen
+   opens (`syncTodaySleepDetail`, offset `0` = today; `255` = all history). It is **not**
+   chained behind activity/HR/stress/SpO2, and never watchdog-skipped as a side effect of
+   an earlier stage failing.
+3. **Two sleep channels**: cmd 39 = main sleep, cmd 62 = nap ("lunch") sleep. Runs through
+   the SDK's own one-op-at-a-time command queue with per-command response callbacks.
+
+QRing also treats "last night" as first-class: the sync explicitly keys sleep to the
+previous day (`dateUtil.addDay(-1)`) plus `calcLastSleep()`/`queryLastSleep()`.
+
+## How the official JRing app does it — different ring, but a transferable lesson
+
+JRing is a **different device/protocol** (SXR `com.sxr.sdk.ble.keepfit` "keepfit" SDK, not
+Colmi/QRing), so its request format doesn't map to Colmi. But PulseLoop also supports jring,
+and JRing's *write reliability* is the model PulseLoop's queue should aspire to.
+
+**Sleep is not a separate request at all.** JRing fetches an entire day — steps + heart rate
++ **sleep** — in one call: `getDataByDay(type=1, day)`, streamed back as repeated
+`onGetDataByDay(...)` and closed by `onGetDataByDayEnd(...)`. Sleep is embedded in the
+unified per-day record; there is no sleep opcode. The app sync loop (`DupMainActivity`,
+lines tagged `[debug: sleep]`) walks **day-by-day, oldest→newest, capped at 7 days**
+(`iMax ≤ 6`), firing the next day's `getDataByDay` only after the previous day's end
+callback. Sleep *windows* (noon nap + night) are configured separately via `setSleepTime`,
+which the ring uses to classify. So JRing chains by **day**, whereas Colmi/PulseLoop chains
+by **data type** — and sleep never sits behind four unrelated stages.
+
+**The write serialization is far more robust than PulseLoop's op-queue** — this is the part
+worth stealing. The SDK's single-threaded `process_cmd_runnable` (`BluetoothLeService`):
+
+- Pulls one `BleCmdItem` at a time from a FIFO queue, strictly one command outstanding.
+- **Blocks the next command until the current one's response arrives** (an `A0` ready-gate) —
+  true request/response coupling, not an optimistic ACK-timeout that frees the slot early.
+- **On `writeCharacteristic()==false`, retries up to 30× at 300 ms** (~9 s of persistence)
+  before giving up — versus PulseLoop's 3 attempts × 150 ms then *drop*.
+- On terminal write failure it **resets the connection** (`u(true)`), and on response
+  timeout it runs a session-timeout reset (`Q()`) — it never spin-drops into a busy stack.
+- **Refuses to interleave non-sync commands during a sync** (only the `a3` opcode passes) —
+  avoids exactly the framework-busy collisions we see in the R10 logs.
+
+Directly relevant to the diagnosis: the storm in the R10 capture is `writeCharacteristic()`
+returning false, which PulseLoop gives up on after 3 quick tries. JRing's SDK would have
+retried that same write ~30 times over ~9 s and reset the link on failure rather than
+silently dropping the command. PulseLoop's queue is the weakest of the four apps studied.
+
+## How iOS (root repo) does it — same design as Android, same weaknesses
+
+iOS mirrors Android almost exactly, and as of 2026-07-10 (upstream `e00c24b`) **has not
+addressed this**:
+
+- Identical `bc 27 01 00 ff 00 ff` request.
+- Same chained pipeline (7 stages — no BP/blood-sugar), sleep is stage 5, same per-stage
+  force-skip watchdog. `querySleep()` just re-runs the whole pipeline; no isolated sleep
+  request.
+- Same manual single-outstanding-op FIFO write queue + 4 s write-ACK timeout (explicitly
+  commented as mirroring Android), and **no per-write resend** — drop-and-advance only.
+- The one recent Colmi sync change (PR #57 `isVitalsBackfill`) adds a post-workout
+  fast-path that **explicitly skips sleep** — the opposite of decoupling it.
+
+The one thing that saves iOS from the *specific* storm in these logs: CoreBluetooth owns
+write serialization and never exposes the raw `writeCharacteristic()==false` busy state, so
+iOS doesn't hit the spin-and-drop loop as often. It is not a better sleep design.
+
+## Recommended fixes (Android), highest value first
+
+1. **Decouple sleep into an on-demand request** (QRing's model): fire `bigDataSleep()`
+   directly when the sleep screen opens / via a dedicated retry, so it doesn't depend on
+   four earlier stages surviving. This is the single biggest win. (iOS would benefit too.)
+2. **Fix the write-queue thrash**: on repeated `writeCharacteristic()==false`, force a
+   reconnect to clear the framework busy flag instead of spin-dropping; don't optimistically
+   free the slot on ACK-timeout into a still-busy stack; make `CONNECTION_PRIORITY_HIGH`
+   actually stick (it's landing at interval 99).
+3. **Consider the today-vs-all offset and the nap channel** — Android always requests full
+   history and ignores nap sleep (QRing cmd 62); querying "today only" post-wake may be more
+   reliable.
+4. **Diagnostics**: un-obfuscate the op label in release and stop letting retries flood the
+   200-entry rawPacket buffer, so the next capture is readable.
+
+## Open questions
+
+- Confirm the R10 (`RT03CR` firmware) actually finalizes the night's sleep record before a
+  post-wake sync (QRing keys sleep to the previous day). If the record isn't finalized yet,
+  no protocol change helps.
+- Verify whether the R10 reports a "new sleep protocol" capability bit like QRing keys on —
+  Android currently assumes the big-data path unconditionally, which is likely correct here
+  but unverified.

--- a/docs/ios-sync.md
+++ b/docs/ios-sync.md
@@ -1,6 +1,6 @@
 # iOS → Android Sync Ledger
 
-Tracks which upstream iOS changes (github.com/foureight84/PulseLoop) have been evaluated
+Tracks which upstream iOS changes (github.com/saksham2001/PulseLoopiOS) have been evaluated
 and/or ported to this Android app. The goal is feature and visual parity, minus the
 intentional platform differences listed at the bottom.
 
@@ -22,10 +22,11 @@ intentional platform differences listed at the bottom.
 
 | | |
 |---|---|
+| **Canonical iOS repo** | `github.com/saksham2001/PulseLoopiOS` (always `main`) |
 | **Fork baseline (iOS)** | `600c7a8` — Merge PR #6, 2026-06-20 |
-| **Last triaged iOS commit** | `80195a6` — Merge PR #44, 2026-07-06 |
-| **Last triage date** | 2026-07-06 |
-| **Range covered** | 138 commits / 28 first-parent items, plus #48/#49/#44 (2026-07-06) |
+| **Last triaged iOS commit** | `e00c24b` — glass-UI fixup, 2026-07-10 |
+| **Last triage date** | 2026-07-10 |
+| **Range covered** | 99 commits / 15 first-parent items since `80195a6` (2026-07-10) |
 
 ---
 
@@ -35,21 +36,79 @@ Ordered roughly by value-for-effort. Status: ☐ open · ☑ done.
 
 | # | iOS PR | Merged | Title | Verdict | Effort | Android commit |
 |---|--------|--------|-------|---------|--------|----------------|
-| ☑ | [#17](https://github.com/foureight84/PulseLoop/pull/17) `26a6075` | 06-24 | Colmi HR enable + activity sample idempotency | **PORT** | M | `1a4f007` |
-| ☑ | [#15](https://github.com/foureight84/PulseLoop/pull/15) `eb5a288` | 07-02 | Sleep sessions splitting at midnight | **ADAPT** | M | `1a4f007` |
-| ☑ | [#11](https://github.com/foureight84/PulseLoop/pull/11) `a582f7a` | 07-01 | Dance activity type | **PORT** | S | `4aad39a` |
-| ☐ | [#43](https://github.com/foureight84/PulseLoop/pull/43) `a280388` | 07-04 | Units consistency (temp/glucose/distance/pace) | **PARTIAL** | M | |
-| ☐ | [#41](https://github.com/foureight84/PulseLoop/pull/41) `102aa35` | 07-04 | Status pill: "Disconnected" not endless "Searching…" | **PARTIAL** | S | |
-| ☑ | [#35](https://github.com/foureight84/PulseLoop/pull/35) `f0a4aee` | 07-01 | Vitals dashboard redesign (zones, cards, rings, detail screens) | **PORT** | XL | `19aac67`+`c978b32`+`f756010` |
-| ☑ | [#19](https://github.com/foureight84/PulseLoop/pull/19) `445be25` | 06-25 | Settings redesign + measurement frequency control | **ADAPT** | L | `f4bcd47` |
-| ☑ | [#9](https://github.com/foureight84/PulseLoop/pull/9) `cd62903` | 06-26 | Coach: multi-provider (Gemini) | **PORT** | L | `049058d`+`4d81a07` |
-| ☑ | [#22](https://github.com/foureight84/PulseLoop/pull/22) `909c5cd` | 06-26 | Coach: OpenRouter provider (fold in #40 slug fix) | **PORT** | L | `049058d`+`4d81a07` |
-| ☑ | [#31](https://github.com/foureight84/PulseLoop/pull/31) `cbb2487` | 06-29 | Coach: image attachments (multimodal) | **PORT** | M | `049058d`+`4d81a07` |
-| ☐ | [#24](https://github.com/foureight84/PulseLoop/pull/24) `be6274f` | 06-28 | Coach scheduler thread-safety crash | **ADAPT** | S | |
+| ☑ | [#17](https://github.com/saksham2001/PulseLoopiOS/pull/17) `26a6075` | 06-24 | Colmi HR enable + activity sample idempotency | **PORT** | M | `1a4f007` |
+| ☑ | [#15](https://github.com/saksham2001/PulseLoopiOS/pull/15) `eb5a288` | 07-02 | Sleep sessions splitting at midnight | **ADAPT** | M | `1a4f007` |
+| ☑ | [#11](https://github.com/saksham2001/PulseLoopiOS/pull/11) `a582f7a` | 07-01 | Dance activity type | **PORT** | S | `4aad39a` |
+| ☐ | [#43](https://github.com/saksham2001/PulseLoopiOS/pull/43) `a280388` | 07-04 | Units consistency (temp/glucose/distance/pace) | **PARTIAL** | M | |
+| ☐ | [#41](https://github.com/saksham2001/PulseLoopiOS/pull/41) `102aa35` | 07-04 | Status pill: "Disconnected" not endless "Searching…" | **PARTIAL** | S | |
+| ☑ | [#35](https://github.com/saksham2001/PulseLoopiOS/pull/35) `f0a4aee` | 07-01 | Vitals dashboard redesign (zones, cards, rings, detail screens) | **PORT** | XL | `19aac67`+`c978b32`+`f756010` |
+| ☑ | [#19](https://github.com/saksham2001/PulseLoopiOS/pull/19) `445be25` | 06-25 | Settings redesign + measurement frequency control | **ADAPT** | L | `f4bcd47` |
+| ☑ | [#9](https://github.com/saksham2001/PulseLoopiOS/pull/9) `cd62903` | 06-26 | Coach: multi-provider (Gemini) | **PORT** | L | `049058d`+`4d81a07` |
+| ☑ | [#22](https://github.com/saksham2001/PulseLoopiOS/pull/22) `909c5cd` | 06-26 | Coach: OpenRouter provider (fold in #40 slug fix) | **PORT** | L | `049058d`+`4d81a07` |
+| ☑ | [#31](https://github.com/saksham2001/PulseLoopiOS/pull/31) `cbb2487` | 06-29 | Coach: image attachments (multimodal) | **PORT** | M | `049058d`+`4d81a07` |
+| ☐ | [#24](https://github.com/saksham2001/PulseLoopiOS/pull/24) `be6274f` | 06-28 | Coach scheduler thread-safety crash | **ADAPT** | S | |
 | ☑ | — | 07-06 | **Design-parity sweep**: iOS dashboard design across all tabs (see notes) | **PORT** | XL | `4aad39a` |
-| ☑ | [#48](https://github.com/foureight84/PulseLoop/pull/48) `aff8574` | 07-05 | Pairing redesign: brand tabs, ring product images, onboarding flow, shared profile/goal editors | **PORT** | L | `a38ddf5` |
-| ☑ | [#49](https://github.com/foureight84/PulseLoop/pull/49) `779740b` | 07-06 | Settings rehaul: device hero card, grouped sections, exact-model matching | **PORT** | L | `de60096` |
-| ☑ | [#44](https://github.com/foureight84/PulseLoop/pull/44) `80195a6` | 07-06 | Home-screen widgets (3 widgets + snapshot pipeline) | **ADAPT** | XL | `c8efccd` |
+| ☑ | [#48](https://github.com/saksham2001/PulseLoopiOS/pull/48) `aff8574` | 07-05 | Pairing redesign: brand tabs, ring product images, onboarding flow, shared profile/goal editors | **PORT** | L | `a38ddf5` |
+| ☑ | [#49](https://github.com/saksham2001/PulseLoopiOS/pull/49) `779740b` | 07-06 | Settings rehaul: device hero card, grouped sections, exact-model matching | **PORT** | L | `de60096` |
+| ☑ | [#44](https://github.com/saksham2001/PulseLoopiOS/pull/44) `80195a6` | 07-06 | Home-screen widgets (3 widgets + snapshot pipeline) | **ADAPT** | XL | `c8efccd` |
+| ☐ | [#71](https://github.com/saksham2001/PulseLoopiOS/pull/71) `4fd008a` | 07-10 | Colmi R08 ring support (catalog entry) | **PORT** | S | |
+| ☐ | [#77](https://github.com/saksham2001/PulseLoopiOS/pull/77) `4241d54` | 07-10 | jring protocol-parity fixes (RingBLEClient + JringSyncEngine + JringClock) | **ADAPT** | L | |
+| ☐ | [#57](https://github.com/saksham2001/PulseLoopiOS/pull/57) `8182d8d` | 07-08 | Activity-recording redesign + post-workout vitals backfill + realtime-HR keepalive rework | **ADAPT** | L | |
+| ☐ | [#54](https://github.com/saksham2001/PulseLoopiOS/pull/54) `cda2e9c` | 07-07 | Coach: MiniMax provider | **PORT** | M | |
+| ☐ | [#64](https://github.com/saksham2001/PulseLoopiOS/pull/64) `338226a` | 07-09 | Long-press to reorder & hide cards (Today/Vitals) | **PORT** | M | |
+| ☐ | [#65](https://github.com/saksham2001/PulseLoopiOS/pull/65) `4a60cfe` | 07-09 | Coach transparency/context rehaul | **ADAPT** | M | |
+| ☐ | [#56](https://github.com/saksham2001/PulseLoopiOS/pull/56) `440aaf4` | 07-10 | TK5 ring support (SmartHealth protocol; own sleep decode + multi-record periodic history) | **PORT** | L | |
+| ☐ | [#61](https://github.com/saksham2001/PulseLoopiOS/pull/61) `39b611f` | 07-08 | Activity UI sync-alerts bugfix | **ADAPT** | S | |
+| ☐ | [#63](https://github.com/saksham2001/PulseLoopiOS/pull/63) `748e79f` | 07-08 | Label jring HR capability as "HR" | **PORT** | S | |
+| ☐ | [#42](https://github.com/saksham2001/PulseLoopiOS/pull/42) `9633fe3` | 07-08 | Coach summary owns top card, no Today duplicate | **PARTIAL** | S | |
+| ☐ | [#74](https://github.com/saksham2001/PulseLoopiOS/pull/74) `ea3e22d` | 07-10 | Move Measurement Frequency into General → Physiology | **ADAPT** | S | |
+
+### 2026-07-10 triage (since #44 / `80195a6` → `e00c24b`, 99 commits / 15 first-parent)
+
+> **Port order: do these AFTER the Colmi sleep-sync fix lands.** The sleep issue
+> (see `colmi-sleep-sync-diagnosis.md`) is the priority; these ports queue behind it.
+> None of them depend on sleep, but we're sequencing deliberately so the sleep fix
+> isn't destabilised by unrelated BLE/activity churn landing at the same time.
+
+**Sleep status check (the reason this triage was run):** iOS has **NOT** addressed the
+Colmi sleep-sync reliability problem. The only Colmi `ColmiSyncEngine` change in this range
+(PR #57's `isVitalsBackfill`) adds a post-workout fast-path that *skips* sleep — sleep is
+still stage 5 of the chained pipeline, still watchdog-force-skipped when a write is dropped.
+No merged or open iOS PR decouples sleep into an independent request or fixes the
+write-queue drop. So there is nothing to port for sleep; Android leads here. See
+`colmi-sleep-sync-diagnosis.md` for the fix plan.
+
+**Relevant → port (queued behind the sleep fix), highest value first:**
+
+- **#71 Colmi R08 support** (`4fd008a`) — add R08 to the wearables catalog. Small, safe,
+  our catalog is the direct analogue of iOS's. Verify advertised-name pattern.
+- **#77 jring protocol-parity fixes** (`4241d54`) — RingBLEClient + JringSyncEngine +
+  new JringClock (+120 lines on the engine). Behavioural BLE fixes for jring; read the diff
+  carefully and port as Kotlin rules. **Do not** let this touch the Colmi path mid-sleep-fix.
+- **#57 activity-recording redesign** (`8182d8d`) — activity tracking rehaul + post-workout
+  vitals backfill (HR+SpO2 only, skips sleep) + wall-clock realtime-HR keepalive (replaces
+  the packet-count keepalive that starved when frames failed to parse — Android has the same
+  packet-count keepalive in `ColmiSyncEngine.observedRealtimeHeartRate`, worth adopting).
+- **#54 MiniMax coach provider** (`cda2e9c`) — another provider in the multi-provider coach;
+  mechanical PORT.
+- **#64 long-press reorder/hide cards** (`338226a`) — Today/Vitals card management. PORT.
+- **#65 coach transparency/context rehaul** (`4a60cfe`) — ADAPT into the Android coach.
+- **#56 TK5 ring support** (`440aaf4`) — whole new ring family (SmartHealth protocol) with
+  its own decoder/encoder/sync engine + multi-record periodic history. Large; only if we
+  want TK5 on Android. Its "periodic multi-record history" is a different sync shape worth
+  studying regardless.
+- **#61 activity UI sync-alerts** (`39b611f`), **#63 jring "HR" label** (`748e79f`),
+  **#42 coach card de-dupe** (`9633fe3`), **#74 measurement-frequency relocation** (`ea3e22d`)
+  — small UI/label ADAPTs.
+
+**Skip (iOS-only or non-portable):**
+
+- **#62 Liquid Glass UI** (`1c3808e`) + **`e00c24b` glass fixups** — iOS 26 material; Android
+  keeps its own surfaces. SKIP as a visual language (cherry-pick spacing tweaks only if a
+  specific screen regressed).
+- **#76 default coach to Apple on-device model** (`5c452c8`) — Apple Intelligence, iOS-only
+  (a standing intentional divergence). SKIP.
+- `6fdfb99` "Remove tasks folder" — repo chore. SKIP.
 
 ### 2026-07-06 design-parity sweep (screen audit → port)
 
@@ -289,18 +348,18 @@ main-thread access from a background worker, and Room calls on the right dispatc
 
 | iOS PR | Title | Note |
 |--------|-------|------|
-| [#20](https://github.com/foureight84/PulseLoop/pull/20) `6fe428f` | Perf re-architecture (event bus, decoupled persistence, memoized today-summary) | Android already built this way: `PulseEventBus` (SharedFlow), `EventPersistenceSubscriber`, `RingSyncCoordinator`, reactive `TodayViewModel` |
-| [#32](https://github.com/foureight84/PulseLoop/pull/32) `3e855ac` | 56ff low-level protocol (user profile, BP calibration, bind handshake, combined measurement, keepalive/watchdog) | This was iOS porting **Android's** work upstream — Android is the origin |
+| [#20](https://github.com/saksham2001/PulseLoopiOS/pull/20) `6fe428f` | Perf re-architecture (event bus, decoupled persistence, memoized today-summary) | Android already built this way: `PulseEventBus` (SharedFlow), `EventPersistenceSubscriber`, `RingSyncCoordinator`, reactive `TodayViewModel` |
+| [#32](https://github.com/saksham2001/PulseLoopiOS/pull/32) `3e855ac` | 56ff low-level protocol (user profile, BP calibration, bind handshake, combined measurement, keepalive/watchdog) | This was iOS porting **Android's** work upstream — Android is the origin |
 
 ## Skipped (iOS-only / docs / CI / release)
 
 | iOS PR / commit | Title | Reason |
 |--------|-------|--------|
-| [#30](https://github.com/foureight84/PulseLoop/pull/30) `c42ec85` | Apple on-device coach (FoundationModels) | iOS 26 Apple Intelligence only. Revisit if Android adopts on-device LLM (AI Edge / ML Kit). The anomaly-detection notifications inside this PR could port separately if ever wanted |
-| [#38](https://github.com/foureight84/PulseLoop/pull/38) `cc9a058` | TestFlight release config | iOS release metadata |
-| [#47](https://github.com/foureight84/PulseLoop/pull/47) [#46](https://github.com/foureight84/PulseLoop/pull/46) [#39](https://github.com/foureight84/PulseLoop/pull/39) | Release-IPA CI workflow + fixes | iOS CI |
-| [#45](https://github.com/foureight84/PulseLoop/pull/45) [#37](https://github.com/foureight84/PulseLoop/pull/37) [#28](https://github.com/foureight84/PulseLoop/pull/28) [#23](https://github.com/foureight84/PulseLoop/pull/23) | Sideloading guide, iOS-vs-Android refresh, MkDocs site, README updates | Docs |
-| [#7](https://github.com/foureight84/PulseLoop/pull/7) `c9897c9` | OSS setup (templates, SwiftLint, CI) | Repo governance; Android repo has its own |
+| [#30](https://github.com/saksham2001/PulseLoopiOS/pull/30) `c42ec85` | Apple on-device coach (FoundationModels) | iOS 26 Apple Intelligence only. Revisit if Android adopts on-device LLM (AI Edge / ML Kit). The anomaly-detection notifications inside this PR could port separately if ever wanted |
+| [#38](https://github.com/saksham2001/PulseLoopiOS/pull/38) `cc9a058` | TestFlight release config | iOS release metadata |
+| [#47](https://github.com/saksham2001/PulseLoopiOS/pull/47) [#46](https://github.com/saksham2001/PulseLoopiOS/pull/46) [#39](https://github.com/saksham2001/PulseLoopiOS/pull/39) | Release-IPA CI workflow + fixes | iOS CI |
+| [#45](https://github.com/saksham2001/PulseLoopiOS/pull/45) [#37](https://github.com/saksham2001/PulseLoopiOS/pull/37) [#28](https://github.com/saksham2001/PulseLoopiOS/pull/28) [#23](https://github.com/saksham2001/PulseLoopiOS/pull/23) | Sideloading guide, iOS-vs-Android refresh, MkDocs site, README updates | Docs |
+| [#7](https://github.com/saksham2001/PulseLoopiOS/pull/7) `c9897c9` | OSS setup (templates, SwiftLint, CI) | Repo governance; Android repo has its own |
 | `25e49fd` `577c5f3` `35d1aa7` `ee42b10` | Direct commits: docs/screenshots/tagline | Docs |
 
 ---


### PR DESCRIPTION
Two independent reliability fixes from investigating [#19](https://github.com/foureight84/PulseLoopAndroid/issues/19) (sleep not tracking, AI same-response). Full analysis in [`docs/colmi-sleep-sync-diagnosis.md`](../blob/fix/colmi-sleep-decouple-and-write-queue-hardening/docs/colmi-sleep-sync-diagnosis.md).

---

## 1. Colmi sleep sync + GATT write-queue hardening

### Problem
A **COLMI R10** returned **no sleep log** after a night's wear. Two on-device diagnostics captures (post-wake) pinned it to **two** issues, neither sleep-specific:

1. **The GATT write queue thrashes.** `writeCharacteristic()` returns `false` ("device busy"); we retried only 3× then **dropped**, and the ACK-timeout **optimistically freed the slot** into a still-busy stack. The logs are a storm of `GATT op dropped after 3 attempts` — sync commands, including the sleep request, get silently dropped.
2. **Sleep is buried mid-pipeline.** `ColmiSyncEngine` runs a chained 9-stage history sync (`ACTIVITY→HR→STRESS→SPO2→SLEEP→HRV→BP→TEMP→BLOOD_SUGAR`); a per-stage watchdog **force-skips** a stalled stage, so a dropped sleep request just vanishes with no error.

Cross-referenced against the decompiled **QRing** and **JRing** apps: QRing fires sleep as a **dedicated on-demand request**, and both SDKs **retry writes persistently and reset the link on terminal failure** rather than dropping. PulseLoop had the weakest queue of the four apps studied.

### Fix (matching QRing)
- **Decouple sleep** — `RingSyncEngine.syncSleepNow()` fires a standalone `bigDataSleep()` off the pipeline (guarded so its completion doesn't advance the full sync, and it no-ops mid-sync). Exposed via `RingSyncCoordinator.syncSleepNow()` and wired to the **Sleep screen opening**, so viewing sleep actively pulls last night's record instead of depending on the SLEEP stage surviving four earlier stages.
- **Harden the write queue** (device-agnostic — benefits jring too): retry a rejected write more persistently (`MAX_OP_ATTEMPTS` 3→6), and — the key change — after a run of dropped/timed-out ops (`OP_FAILURE_RECONNECT_THRESHOLD`) **force a reconnect** to clear the stuck framework busy flag instead of spin-dropping commands.
- **Diagnostics** — readable op labels in release logs (were R8-obfuscated to `"J"`; now e.g. `cmd:0x27`), and publish the outgoing `RawPacket` once per op so a retry storm no longer floods the 200-entry diagnostics buffer.

**jring:** no sync change needed — it fetches sleep in one bulk request (nothing to decouple) and shares the device-agnostic write queue, so the hardening covers it. `syncSleepNow()` is a no-op default for jring.

---

## 2. Coach: surface real errors instead of a canned reply (fixes #19 "AI same response")

### Problem
With an OpenAI key, **every question returned the same answer**. Root cause was **error masking**, not a repeated model reply: a failed coach turn returns a fixed `CoachFallbacks.fallback()` string in `TurnResult.assistant` with the real cause in `TurnResult.error` — but `CoachViewModel.sendMessage` rendered only `result.assistant.plainText` and **discarded `result.error`**. So every failing turn (e.g. a model the user's key can't access, like the default `gpt-5.4`, or a `reasoning` field a non-reasoning model rejects) showed the identical canned bubble, hiding the actual HTTP error.

### Fix
- **Surface `result.error`** as a distinct red error bubble showing the real code + reason (e.g. *"HTTP 404 · The model `gpt-5.4` does not exist or you don't have access"*), so the user can act on it. The `CoachTurnError` plumbing already existed — it just wasn't wired into the Android ViewModel.
- **Defensively gate the `reasoning` field by model** — `reasoningParams(effort, model)` drops `reasoning` for non-reasoning models (`gpt-4o`/`gpt-4`/`gpt-3.5`/`chatgpt`), which otherwise reject every request when paired with a set effort. Defaults to allowing it so unknown/future models aren't blocked. Applied to both the chat orchestrator and the summary generator.

---

## Testing
- `ColmiSleepSyncTest` (5 cases: standalone request fires exactly `bc 27 …`; no-op during a full sync; standalone completion doesn't advance to HRV; in-pipeline completion still does; no double-request).
- `OpenAIRequestBuilderTest` extended with reasoning-by-model gate cases (now 7).
- `:app:compileReleaseKotlin` + full `:app:testDebugUnitTest` green.
- ⚠️ **Not yet on-device verified.** The write-queue recovery path needs a real wedged link (the R10 report's realme/Android-16-class stack) to exercise; the coach red-bubble UI change is compile-verified but not screenshotted. Confirming signals: in logcat, `cmd:0x27` issuing shortly after the Sleep screen opens and `GATT op slot wedged — forcing reconnect` (instead of an endless drop storm); in the coach, a red error bubble with the real provider message instead of the canned reply.

## Out of scope
- **Issue #19's third item (HR reported when not worn)** is a PPG false positive — the Colmi protocol as implemented exposes no wear/contact signal (iOS has none either). Being handled separately with the reporter, not in this PR.
- Making `CONNECTION_PRIORITY_HIGH` actually stick (R10 negotiated `interval=99`); QRing's today-vs-all sleep offset and nap channel — noted as follow-ups.

Also folds in the sleep-research docs and the 2026-07-10 iOS sync-ledger triage from this investigation.
