### PR TITLE
Fix Colmi sleep persistence (#19) + coach chat issues (#22)

### DIFF
--- a/app/src/debug/res/values/strings.xml
+++ b/app/src/debug/res/values/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Debug-only launcher label so this build is distinguishable from a release install
+         on the same device (paired with the .debug applicationId suffix). -->
+    <string name="app_name">PulseLoop Debug</string>
+</resources>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -37,7 +37,8 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:launchMode="singleTask">
+            android:launchMode="singleTask"
+            android:windowSoftInputMode="adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -28,7 +28,7 @@
     <application
         android:name=".PulseLoopApplication"
         android:allowBackup="false"
-        android:label="PulseLoop"
+        android:label="@string/app_name"
         android:supportsRtl="true"
         android:icon="@mipmap/ic_launcher"
         android:roundIcon="@mipmap/ic_launcher_round"

--- a/app/src/main/java/com/pulseloop/coach/config/CoachModelPresets.kt
+++ b/app/src/main/java/com/pulseloop/coach/config/CoachModelPresets.kt
@@ -5,14 +5,30 @@ package com.pulseloop.coach.config
  * Preset Gemini model choices surfaced in Settings.
  */
 enum class GeminiModel(val slug: String, val blurb: String) {
-    FLASH_25("gemini-2.5-flash", "Fast & capable (default)"),
-    FLASH_20("gemini-2.0-flash", "Previous generation"),
-    PRO_25("gemini-2.5-pro", "Best reasoning");
+    // Rolling `-latest` aliases (docs: ai.google.dev/gemini-api/docs/models) point at the most
+    // recent release for each variation and are updated with a two-week notice — so the presets
+    // never go stale again (issue #22). Current generation behind them: 3.5 Flash / 3.1 Flash-Lite.
+    FLASH_LATEST("gemini-flash-latest", "Fast & capable (default)"),
+    FLASH_LITE_LATEST("gemini-flash-lite-latest", "Fastest & lowest cost"),
+    PRO_LATEST("gemini-pro-latest", "Best reasoning");
 
     val label: String get() = slug
 
     companion object {
-        val DEFAULT = FLASH_25
+        val DEFAULT = FLASH_LATEST
+
+        /**
+         * Remap a retired 2.x preset slug to the current rolling alias so a user stored on a
+         * now-deprecated model isn't stuck serving 404s (issue #22 — "model old"). Applied on
+         * read in [CoachProviderSettingsStore.geminiModel]. A slug we don't recognise (a model the
+         * user typed elsewhere, or one already current) passes through untouched.
+         */
+        fun migrateSlug(slug: String): String = when (slug) {
+            "gemini-2.5-flash", "gemini-2.0-flash", "gemini-1.5-flash" -> FLASH_LATEST.slug
+            "gemini-2.5-flash-lite", "gemini-2.0-flash-lite" -> FLASH_LITE_LATEST.slug
+            "gemini-2.5-pro", "gemini-1.5-pro" -> PRO_LATEST.slug
+            else -> slug
+        }
     }
 }
 

--- a/app/src/main/java/com/pulseloop/coach/config/CoachProviderSettingsStore.kt
+++ b/app/src/main/java/com/pulseloop/coach/config/CoachProviderSettingsStore.kt
@@ -39,9 +39,10 @@ class CoachProviderSettingsStore(context: Context) {
 
     val hasOpenRouterKey: Boolean get() = openRouterApiKey.isNotBlank()
 
-    /** Gemini model slug (see [GeminiModel] presets). */
+    /** Gemini model slug (see [GeminiModel] presets). Retired 2.x slugs are remapped to the
+     *  current rolling alias on read so no one stays stuck on a deprecated model (issue #22). */
     var geminiModel: String
-        get() = prefs.getString(KEY_GEMINI_MODEL, GeminiModel.DEFAULT.slug) ?: GeminiModel.DEFAULT.slug
+        get() = GeminiModel.migrateSlug(prefs.getString(KEY_GEMINI_MODEL, GeminiModel.DEFAULT.slug) ?: GeminiModel.DEFAULT.slug)
         set(value) { prefs.edit().putString(KEY_GEMINI_MODEL, value).apply() }
 
     /** OpenRouter `vendor/model` slug. Free-form; blank falls back to the

--- a/app/src/main/java/com/pulseloop/service/EventPersistenceSubscriber.kt
+++ b/app/src/main/java/com/pulseloop/service/EventPersistenceSubscriber.kt
@@ -309,12 +309,12 @@ class EventPersistenceSubscriber(
         val deepMin = merged.filter { it.stageRaw == SleepStage.DEEP.name }.sumOf { it.durationMinutes }
         val score = computeSleepScore(deepMin, totalMin)
 
-        // Rewrite the full accumulated set with start minutes relative to the night start.
-        db.sleepStageBlockDao().deleteBySession(sessionId)
-        merged.forEach {
-            db.sleepStageBlockDao().insert(it.copy(startMinute = ((it.startAt - sessionStart) / 60_000L).toInt()))
-        }
-
+        // Upsert the parent session BEFORE its stage blocks. sleep_stage_blocks has a foreign key
+        // to sleep_sessions(id), and both tables are cleared on every connect (see
+        // DeviceStateChanged), so the first packet of a night finds no parent row: inserting blocks
+        // first throws FOREIGN KEY constraint failed, persist() swallows it, and the whole night is
+        // silently dropped. Parent-first matches DemoDataSeeder — which is exactly why demo sleep
+        // persists while real ring sleep did not.
         val existing = db.sleepSessionDao().ringByDay(dayStart)
         db.sleepSessionDao().upsert(
             (existing ?: SleepSessionEntity(id = sessionId, date = dayStart, startAt = sessionStart, endAt = sessionEnd, totalMinutes = totalMin, score = score)).copy(
@@ -326,6 +326,12 @@ class EventPersistenceSubscriber(
                 updatedAt = System.currentTimeMillis(),
             )
         )
+
+        // Rewrite the full accumulated set with start minutes relative to the night start.
+        db.sleepStageBlockDao().deleteBySession(sessionId)
+        merged.forEach {
+            db.sleepStageBlockDao().insert(it.copy(startMinute = ((it.startAt - sessionStart) / 60_000L).toInt()))
+        }
     }
 
     /**

--- a/app/src/main/java/com/pulseloop/ui/PulseLoopApp.kt
+++ b/app/src/main/java/com/pulseloop/ui/PulseLoopApp.kt
@@ -243,7 +243,8 @@ fun PulseLoopApp() {
                 // Shared iOS-style header (PULSELOOP eyebrow + greeting + status pill) on tab
                 // routes only; pushed screens (settings, details, pairing) bring their own bars.
                 val navBackStackEntry by navController.currentBackStackEntryAsState()
-                val onTabRoute = navBackStackEntry?.destination?.route in tabRoutes
+                val route = navBackStackEntry?.destination?.route
+                val onTabRoute = route in tabRoutes
                 if (onTabRoute && !isLandscape) {
                     Column(
                         Modifier
@@ -257,30 +258,37 @@ fun PulseLoopApp() {
                             }
                             .windowInsetsPadding(WindowInsets.statusBars),
                     ) {
-                        val ble by bleClient.state.collectAsState()
-                        val storedDevice by db.deviceDao().currentFlow()
-                            .collectAsState(initial = null)
-                        // Prefer live BLE state; fall back to the stored device so demo data
-                        // shows its ring instead of a permanently blank pill (RootViews.swift).
-                        val liveActive = ble.connectionState in setOf(
-                            com.pulseloop.ring.RingConnectionState.CONNECTED,
-                            com.pulseloop.ring.RingConnectionState.CONNECTING,
-                            com.pulseloop.ring.RingConnectionState.RECONNECTING,
-                            com.pulseloop.ring.RingConnectionState.SCANNING,
-                        )
-                        AppHeader(
-                            state = if (liveActive) ble.connectionState
-                                else storedDevice?.state ?: ble.connectionState,
-                            batteryPercent = ble.batteryPercent ?: storedDevice?.batteryPercent,
-                            onOpenSettings = { navController.navigate("settings") },
-                        )
-                        // Thin sync-progress accent under the greeting while history streams in.
-                        val syncPct = coordinator.syncProgress.collectAsState().value
-                        if (syncPct != null) {
-                            LinearProgressIndicator(
-                                progress = { (syncPct.coerceIn(0, 100)) / 100f },
-                                modifier = Modifier.fillMaxWidth().height(2.dp),
+                        if (route == "coach") {
+                            // Coach keeps its bespoke avatar header, rendered here as the same
+                            // frosted glass bar the other tabs use so the chat scrolls under it
+                            // (owner choice, issue #22).
+                            CoachHeader(onNewChat = { coachVM.newConversation() })
+                        } else {
+                            val ble by bleClient.state.collectAsState()
+                            val storedDevice by db.deviceDao().currentFlow()
+                                .collectAsState(initial = null)
+                            // Prefer live BLE state; fall back to the stored device so demo data
+                            // shows its ring instead of a permanently blank pill (RootViews.swift).
+                            val liveActive = ble.connectionState in setOf(
+                                com.pulseloop.ring.RingConnectionState.CONNECTED,
+                                com.pulseloop.ring.RingConnectionState.CONNECTING,
+                                com.pulseloop.ring.RingConnectionState.RECONNECTING,
+                                com.pulseloop.ring.RingConnectionState.SCANNING,
                             )
+                            AppHeader(
+                                state = if (liveActive) ble.connectionState
+                                    else storedDevice?.state ?: ble.connectionState,
+                                batteryPercent = ble.batteryPercent ?: storedDevice?.batteryPercent,
+                                onOpenSettings = { navController.navigate("settings") },
+                            )
+                            // Thin sync-progress accent under the greeting while history streams in.
+                            val syncPct = coordinator.syncProgress.collectAsState().value
+                            if (syncPct != null) {
+                                LinearProgressIndicator(
+                                    progress = { (syncPct.coerceIn(0, 100)) / 100f },
+                                    modifier = Modifier.fillMaxWidth().height(2.dp),
+                                )
+                            }
                         }
                     }
                 }
@@ -385,7 +393,16 @@ fun PulseLoopApp() {
                     val id = backStackEntry.arguments?.getString("id") ?: return@paddedComposable
                     WorkoutSummaryScreen(sessionId = id, onBack = { navController.popBackStack() })
                 }
-                paddedComposable("coach") { CoachScreen(navController = navController, viewModel = coachVM) }
+                // Coach draws full-bleed under the glass top/bottom bars (like the other tabs), so
+                // the chat frosts under its header and the composer can clear the keyboard itself.
+                composable("coach") {
+                    CoachScreen(
+                        navController = navController,
+                        viewModel = coachVM,
+                        topBarPadding = topPad,
+                        bottomBarPadding = barPad,
+                    )
+                }
                 paddedComposable("settings") { SettingsScreen(navController, bleClient, coordinator) }
                 // Settings detail screens (iOS #49): each hub row pushes one of these.
                 paddedComposable("settings/wearable") {

--- a/app/src/main/java/com/pulseloop/ui/PulseLoopApp.kt
+++ b/app/src/main/java/com/pulseloop/ui/PulseLoopApp.kt
@@ -245,6 +245,19 @@ fun PulseLoopApp() {
                 val navBackStackEntry by navController.currentBackStackEntryAsState()
                 val route = navBackStackEntry?.destination?.route
                 val onTabRoute = route in tabRoutes
+                if (onTabRoute && isLandscape) {
+                    // Edge-to-edge draws content under the transparent status bar. In landscape the
+                    // tabs render no full header, so without a backdrop scrolled content (chat
+                    // bubbles, charts) bleeds through the status bar. Keep a status-bar-height glass
+                    // strip so the status bar stays legible on every tab — matching the landscape
+                    // bottom bar's glass — while content still scrolls under it.
+                    Box(
+                        Modifier
+                            .fillMaxWidth()
+                            .hazeEffect(state = hazeState, style = glassStyle)
+                            .windowInsetsPadding(WindowInsets.statusBars),
+                    )
+                }
                 if (onTabRoute && !isLandscape) {
                     Column(
                         Modifier

--- a/app/src/main/java/com/pulseloop/ui/screens/CoachScreen.kt
+++ b/app/src/main/java/com/pulseloop/ui/screens/CoachScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.pulseloop.coach.attachments.CoachAttachmentRef
@@ -53,6 +54,8 @@ import com.pulseloop.ui.viewmodels.CoachViewModel
 fun CoachScreen(
     navController: androidx.navigation.NavController? = null,
     viewModel: CoachViewModel? = null,
+    topBarPadding: Dp = 0.dp,
+    bottomBarPadding: Dp = 0.dp,
 ) {
     val state by (viewModel?.state?.collectAsState() ?: remember {
         mutableStateOf(CoachViewModel.CoachState())
@@ -66,12 +69,15 @@ fun CoachScreen(
     }
 
     Column(Modifier.fillMaxSize().background(PulseColors.background)) {
-        CoachSubHeader(onNewChat = { viewModel?.newConversation() })
-
         LazyColumn(
             modifier = Modifier.weight(1f),
             state = listState,
-            contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+            // The coach header is the frosted glass top bar (rendered by PulseLoopApp); pad the
+            // chat down by its height so messages scroll up UNDER it like every other tab.
+            contentPadding = PaddingValues(
+                start = 16.dp, end = 16.dp,
+                top = topBarPadding + 8.dp, bottom = 8.dp,
+            ),
             verticalArrangement = Arrangement.spacedBy(10.dp),
         ) {
             items(state.messages.size) { idx ->
@@ -98,6 +104,7 @@ fun CoachScreen(
             onInputChange = { inputText = it },
             isThinking = state.isThinking,
             showChips = state.messages.count { it.role == "user" } == 0,
+            bottomBarPadding = bottomBarPadding,
             onSend = { text, staged ->
                 viewModel?.sendMessage(text, staged)
                 inputText = ""
@@ -106,14 +113,19 @@ fun CoachScreen(
     }
 }
 
-// ─────────────────────────── Sub-header ───────────────────────────
+// ─────────────────────────── Header ───────────────────────────
 
+/**
+ * Coach avatar header — the bespoke "PulseLoop Coach" identity row with a new-chat button.
+ * [PulseLoopApp] renders this as the Coach tab's frosted glass top bar, so it carries NO opaque
+ * background of its own (the caller supplies the haze material, exactly like [AppHeader]); the
+ * chat then scrolls under it.
+ */
 @Composable
-private fun CoachSubHeader(onNewChat: () -> Unit) {
+fun CoachHeader(onNewChat: () -> Unit) {
     Row(
         Modifier
             .fillMaxWidth()
-            .background(PulseColors.secondaryBackground)
             .padding(horizontal = 16.dp, vertical = 10.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(12.dp),
@@ -218,6 +230,7 @@ private fun Composer(
     onInputChange: (String) -> Unit,
     isThinking: Boolean,
     showChips: Boolean,
+    bottomBarPadding: Dp = 0.dp,
     onSend: (String, List<CoachAttachmentRef>) -> Unit,
 ) {
     val ctx = LocalContext.current
@@ -240,11 +253,18 @@ private fun Composer(
     }
     val canSend = (inputText.isNotBlank() || staged.isNotEmpty()) && !isThinking
 
+    // Coach draws full-bleed under the bottom nav bar, so the composer must lift itself: above the
+    // keyboard while it's open, above the nav bar otherwise. max() (not sum) of the two insets
+    // keeps the composer flush to the keyboard instead of leaving a nav-bar-height gap when typing.
+    // Fixes the keyboard overlapping the input (issue #22).
+    val imeBottom = WindowInsets.ime.asPaddingValues().calculateBottomPadding()
+    val composerBottom = maxOf(bottomBarPadding, imeBottom)
+
     Column(
         Modifier
             .fillMaxWidth()
             .background(PulseColors.secondaryBackground)
-            .padding(bottom = 8.dp),
+            .padding(bottom = composerBottom + 8.dp),
     ) {
         if (showChips) {
             Row(

--- a/app/src/main/java/com/pulseloop/ui/screens/CoachScreen.kt
+++ b/app/src/main/java/com/pulseloop/ui/screens/CoachScreen.kt
@@ -1,5 +1,6 @@
 package com.pulseloop.ui.screens
 
+import android.content.res.Configuration
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
@@ -31,6 +32,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
@@ -63,6 +65,10 @@ fun CoachScreen(
     var inputText by remember { mutableStateOf("") }
     val listState = rememberLazyListState()
     val ctx = LocalContext.current
+    // Landscape drops the shared glass header (and its new-chat button), so offer new-chat inline
+    // with the composer instead — the header's affordance brought down in line with the input.
+    val isLandscape =
+        LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE
 
     LaunchedEffect(state.messages.size) {
         if (state.messages.isNotEmpty()) listState.animateScrollToItem(state.messages.size - 1)
@@ -105,6 +111,8 @@ fun CoachScreen(
             isThinking = state.isThinking,
             showChips = state.messages.count { it.role == "user" } == 0,
             bottomBarPadding = bottomBarPadding,
+            showNewChat = isLandscape,
+            onNewChat = { viewModel?.newConversation() },
             onSend = { text, staged ->
                 viewModel?.sendMessage(text, staged)
                 inputText = ""
@@ -231,6 +239,8 @@ private fun Composer(
     isThinking: Boolean,
     showChips: Boolean,
     bottomBarPadding: Dp = 0.dp,
+    showNewChat: Boolean = false,
+    onNewChat: () -> Unit = {},
     onSend: (String, List<CoachAttachmentRef>) -> Unit,
 ) {
     val ctx = LocalContext.current
@@ -322,6 +332,22 @@ private fun Composer(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(8.dp),
         ) {
+            if (showNewChat) {
+                // Landscape has no Coach header — bring its new-chat button down in line with the
+                // input. Bordered circle + "+" glyph mirrors the header's affordance exactly so the
+                // control reads the same in both orientations.
+                Box(
+                    Modifier
+                        .size(40.dp)
+                        .clip(CircleShape)
+                        .background(PulseColors.card)
+                        .border(1.dp, PulseColors.borderSubtle, CircleShape)
+                        .clickable(onClick = onNewChat),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Icon(Icons.Filled.Add, "New chat", tint = PulseColors.textSecondary, modifier = Modifier.size(18.dp))
+                }
+            }
             if (imageInputEnabled) {
                 Box(
                     Modifier

--- a/app/src/main/java/com/pulseloop/ui/screens/SettingsSubScreens.kt
+++ b/app/src/main/java/com/pulseloop/ui/screens/SettingsSubScreens.kt
@@ -244,6 +244,13 @@ fun CoachSettingsScreen(onBack: () -> Unit) {
                         label: String, value: String, visible: Boolean, saved: Boolean,
                         onValue: (String) -> Unit, onVisibility: () -> Unit, onSave: () -> Unit, onRemove: () -> Unit,
                     ) {
+                        // Saving an API key gave no feedback (issue #22). Flash a brief "Saved ✓"
+                        // confirmation after a save from either the button or the keyboard's Done.
+                        var justSaved by remember { mutableStateOf(false) }
+                        LaunchedEffect(justSaved) {
+                            if (justSaved) { kotlinx.coroutines.delay(2000); justSaved = false }
+                        }
+                        val save = { onSave(); justSaved = true }
                         OutlinedTextField(
                             value = value,
                             onValueChange = onValue,
@@ -261,15 +268,23 @@ fun CoachSettingsScreen(onBack: () -> Unit) {
                                     )
                                 }
                             },
-                            keyboardActions = KeyboardActions(onDone = { onSave() }),
+                            keyboardActions = KeyboardActions(onDone = { if (value.isNotBlank()) save() }),
                         )
-                        Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                            Button(onClick = onSave, enabled = value.isNotBlank(), modifier = Modifier.weight(1f)) {
+                        Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = Alignment.CenterVertically) {
+                            Button(onClick = save, enabled = value.isNotBlank(), modifier = Modifier.weight(1f)) {
                                 Text(if (saved) "Update Key" else "Save Key")
                             }
                             if (saved) {
                                 OutlinedButton(onClick = onRemove, modifier = Modifier.weight(1f)) { Text("Remove") }
                             }
+                        }
+                        if (justSaved) {
+                            Text(
+                                "Saved ✓",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = PulseColors.success,
+                                modifier = Modifier.padding(top = 4.dp),
+                            )
                         }
                     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <!-- Launcher label. Overridden to "PulseLoop Debug" in the debug source set so a debug
+         build (com.pulseloop.debug) is visually distinct from a release install on the same phone. -->
+    <string name="app_name">PulseLoop</string>
+
     <!-- Home-screen widgets (iOS #44). -->
     <string name="widget_activity_label">Daily Activity</string>
     <string name="widget_activity_description">Steps, distance, and calories with your progress rings.</string>

--- a/app/src/test/java/com/pulseloop/coach/CoachModelPresetsTest.kt
+++ b/app/src/test/java/com/pulseloop/coach/CoachModelPresetsTest.kt
@@ -27,8 +27,24 @@ class CoachModelPresetsTest {
     }
 
     @Test
-    fun testGeminiDefaultIsFlash25() {
-        assertEquals("gemini-2.5-flash", GeminiModel.DEFAULT.slug)
+    fun testGeminiDefaultIsFlashLatestAlias() {
+        // Issue #22: presets moved to Google's rolling `-latest` aliases so they never go stale.
+        assertEquals("gemini-flash-latest", GeminiModel.DEFAULT.slug)
+    }
+
+    @Test
+    fun testRetiredGeminiSlugsMigrateToCurrentAliases() {
+        assertEquals("gemini-flash-latest", GeminiModel.migrateSlug("gemini-2.5-flash"))
+        assertEquals("gemini-flash-latest", GeminiModel.migrateSlug("gemini-2.0-flash"))
+        assertEquals("gemini-flash-lite-latest", GeminiModel.migrateSlug("gemini-2.5-flash-lite"))
+        assertEquals("gemini-pro-latest", GeminiModel.migrateSlug("gemini-2.5-pro"))
+    }
+
+    @Test
+    fun testUnknownOrCurrentGeminiSlugPassesThroughMigration() {
+        // A current alias or a slug the user set elsewhere must not be rewritten.
+        assertEquals("gemini-flash-latest", GeminiModel.migrateSlug("gemini-flash-latest"))
+        assertEquals("gemini-3.5-flash", GeminiModel.migrateSlug("gemini-3.5-flash"))
     }
 
     @Test


### PR DESCRIPTION
## Colmi sleep never persists — FK insert ordering (#19)

A **new** R09 user on build 11 reported sleep still not working — a different device/user than the R10 case the PR #21 write-queue fix addressed. Their diagnostics show a **healthy link** (temperature/HRV streaming, none of the write-queue thrash) but sleep never appears, with this at connect:

```
E/EventPersistence: Failed to persist event
SQLiteConstraintException: FOREIGN KEY constraint failed (787)
```

**Root cause:** `EventPersistenceSubscriber.upsertSleepSession()` inserted the child `sleep_stage_blocks` (FK → `sleep_sessions.id`, Room enforces FKs by default) **before** upserting the parent session. Both tables are cleared on every connect, so the first `SleepTimeline` packet of a night finds no parent row → the block insert throws → `persist()`'s try/catch swallows it → the whole night is dropped silently.

This ordering has existed since the initial commit; it was masked while the flaky write queue dropped the sleep request before any packet arrived. PR #21 hardened the queue, so packets now arrive over a good link and expose the latent bug. `DemoDataSeeder` already writes these tables parent-first — which is exactly why demo sleep rendered while real ring sleep did not.

**Fix:** upsert the session first, then delete+insert its blocks (pure reordering; all values are computed before any write). Clear-on-connect, waking-day keying, and stitch-by-startAt de-dup are untouched.

## Coach chat issues (#22)

- **Gemini models were stuck on 2.x.** Moved presets to Google's documented rolling `-latest` aliases (`gemini-flash-latest` / `-flash-lite-latest` / `-pro-latest`) so they never go stale again, plus a getter-level remap so users already stored on a retired 2.x slug auto-move forward.
- **Missing top glass effect.** The Coach tab was the only one rendered as an opaque inset. Its bespoke "PulseLoop Coach" avatar header now renders as the frosted glass top bar (same haze pattern as every other tab), with the chat scrolling under it.
- **Keyboard overlapped the composer.** Coach now draws full-bleed under the bottom bar; the composer lifts itself with `max(navBar, ime)` — flush to the keyboard when open, above the nav bar otherwise.
- **No feedback on API-key save.** Flashes a brief "Saved ✓" after saving (button or keyboard Done).

## Also
- `chore`: debug builds now label as **"PulseLoop Debug"** (release unaffected) so a debug install is distinguishable alongside a release build.

## Verification
- `./gradlew testDebugUnitTest` green (353 tests; updated the Gemini preset test + added migration guards).
- Debug APK builds and installs alongside release on a Pixel 8.
- ⚠️ Not yet verified on-device against a real ring with a recorded night — the sleep fix is verified by root-cause + tests; recommend confirming the hypnogram populates with no FK error in logcat before cutting the release.

Closes #19
Closes #22