### PR TITLE
Fix Gemini thought_signature 400 (#22) + activity tile clipping (#24)

### DIFF
--- a/app/src/main/java/com/pulseloop/coach/gemini/GeminiClient.kt
+++ b/app/src/main/java/com/pulseloop/coach/gemini/GeminiClient.kt
@@ -367,7 +367,15 @@ class GeminiClient(
             val fc = part["functionCall"] as? JsonObject
             if (text != null) {
                 textParts.add(TextContent(text))
-                modelParts.add(JsonObject(mapOf("text" to JsonPrimitive(text))))
+                // Gemini 3.x thinking models attach an encrypted thoughtSignature to response
+                // parts (functionCall AND final output); the API rejects (HTTP 400 "missing a
+                // thought_signature in functionCall parts") any replayed model turn that drops it.
+                // Carry it through verbatim on every reconstructed part so appendContinuation's
+                // replay stays valid (issue #22).
+                modelParts.add(JsonObject(buildMap {
+                    put("text", JsonPrimitive(text))
+                    part["thoughtSignature"]?.let { put("thoughtSignature", it) }
+                }))
             } else if (fc != null) {
                 val name = (fc["name"] as? JsonPrimitive)?.contentOrNull ?: continue
                 val args = fc["args"] as? JsonObject ?: JsonObject(emptyMap())
@@ -375,12 +383,13 @@ class GeminiClient(
                 val callId = "gemini_call_" + UUID.randomUUID().toString().replace("-", "").take(12)
                 callIdToName[callId] = name
                 outputItems.add(FunctionCallOutput(id = callId, callId = callId, name = name, arguments = argsStr))
-                modelParts.add(JsonObject(mapOf(
-                    "functionCall" to JsonObject(mapOf(
+                modelParts.add(JsonObject(buildMap {
+                    put("functionCall", JsonObject(mapOf(
                         "name" to JsonPrimitive(name),
                         "args" to args,
-                    )),
-                )))
+                    )))
+                    part["thoughtSignature"]?.let { put("thoughtSignature", it) }
+                }))
             }
         }
         // One MessageOutput carrying every text part — OpenAIResponse.outputText

--- a/app/src/main/java/com/pulseloop/ui/components/TodayTiles.kt
+++ b/app/src/main/java/com/pulseloop/ui/components/TodayTiles.kt
@@ -17,6 +17,8 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.PlatformTextStyle
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -108,23 +110,32 @@ fun ActivityTile(
                 strokeWidth = 9.dp,
                 ringSpacing = 4.dp,
             )
-            Column(verticalArrangement = Arrangement.spacedBy(4.dp), modifier = Modifier.weight(1f)) {
+            // Three metrics (steps/distance/calories) share the fixed-height tile. At 22.sp the
+            // third value overflowed and clipped the calories row (issue #24). Keep each pair
+            // compact — 16.sp value, tight line heights, and no font padding (Compose's default
+            // includeFontPadding adds several dp per line) — so all three fit with margin.
+            val compact = TextStyle(platformStyle = PlatformTextStyle(includeFontPadding = false))
+            Column(verticalArrangement = Arrangement.spacedBy(3.dp), modifier = Modifier.weight(1f)) {
                 values.forEach { value ->
                     Column {
                         Text(
                             value.label.uppercase(),
                             fontSize = 10.sp,
+                            lineHeight = 12.sp,
                             fontWeight = FontWeight.SemiBold,
                             letterSpacing = 0.8.sp,
                             color = value.color,
+                            style = compact,
                         )
                         Text(
                             value.text,
-                            fontSize = 22.sp,
+                            fontSize = 16.sp,
+                            lineHeight = 18.sp,
                             fontWeight = FontWeight.SemiBold,
                             color = PulseColors.textPrimary,
                             maxLines = 1,
                             overflow = TextOverflow.Ellipsis,
+                            style = compact,
                         )
                     }
                 }

--- a/app/src/test/java/com/pulseloop/coach/GeminiClientTest.kt
+++ b/app/src/test/java/com/pulseloop/coach/GeminiClientTest.kt
@@ -191,6 +191,82 @@ class GeminiClientTest {
         assertEquals(61, fr["response"]!!.jsonObject["result"]!!.jsonObject["avg"]!!.jsonPrimitive.int)
     }
 
+    @Test
+    fun testThoughtSignatureIsPreservedWhenReplayingModelParts() {
+        // Gemini 3.x attaches an encrypted thoughtSignature to functionCall/text parts; the API
+        // rejects (HTTP 400) any replayed model turn that drops it. The replay must echo it back
+        // verbatim on every part (issue #22).
+        val client = GeminiClient("key")
+        client.buildRequestBody(request(listOf(msg("user", "hi"))))
+
+        val response = client.ingestResponse(JsonObject(mapOf(
+            "candidates" to JsonArray(listOf(JsonObject(mapOf(
+                "content" to JsonObject(mapOf(
+                    "parts" to JsonArray(listOf(
+                        JsonObject(mapOf(
+                            "text" to JsonPrimitive("let me check"),
+                            "thoughtSignature" to JsonPrimitive("SIG_TEXT"),
+                        )),
+                        JsonObject(mapOf(
+                            "functionCall" to JsonObject(mapOf(
+                                "name" to JsonPrimitive("get_hr"),
+                                "args" to JsonObject(mapOf("days" to JsonPrimitive(7))),
+                            )),
+                            "thoughtSignature" to JsonPrimitive("SIG_FC"),
+                        )),
+                    )),
+                )),
+            )))),
+        )))
+        val call = response.output.filterIsInstance<FunctionCallOutput>().single()
+
+        val toolResult = JsonObject(mapOf(
+            "type" to JsonPrimitive("function_call_output"),
+            "call_id" to JsonPrimitive(call.callId),
+            "output" to JsonPrimitive("""{"avg":61}"""),
+        ))
+        val body = client.buildRequestBody(request(
+            listOf(toolResult), previousResponseId = response.id,
+        ))
+
+        // Replayed model turn keeps the signature on both the text part and the functionCall part.
+        val modelParts = body["contents"]!!.jsonArray[1].jsonObject["parts"]!!.jsonArray.map { it.jsonObject }
+        val textPart = modelParts.single { it.containsKey("text") }
+        assertEquals("SIG_TEXT", textPart["thoughtSignature"]!!.jsonPrimitive.content)
+        val fcPart = modelParts.single { it.containsKey("functionCall") }
+        assertEquals("SIG_FC", fcPart["thoughtSignature"]!!.jsonPrimitive.content)
+    }
+
+    @Test
+    fun testMissingThoughtSignatureOmitsTheKey() {
+        // Gemini 2.5 responses carry no signature — the replayed part must not invent one.
+        val client = GeminiClient("key")
+        client.buildRequestBody(request(listOf(msg("user", "hi"))))
+        val response = client.ingestResponse(JsonObject(mapOf(
+            "candidates" to JsonArray(listOf(JsonObject(mapOf(
+                "content" to JsonObject(mapOf(
+                    "parts" to JsonArray(listOf(JsonObject(mapOf(
+                        "functionCall" to JsonObject(mapOf(
+                            "name" to JsonPrimitive("get_hr"),
+                            "args" to JsonObject(emptyMap()),
+                        )),
+                    )))),
+                )),
+            )))),
+        )))
+        val call = response.output.filterIsInstance<FunctionCallOutput>().single()
+        val body = client.buildRequestBody(request(
+            listOf(JsonObject(mapOf(
+                "type" to JsonPrimitive("function_call_output"),
+                "call_id" to JsonPrimitive(call.callId),
+                "output" to JsonPrimitive("{}"),
+            ))),
+            previousResponseId = response.id,
+        ))
+        val fcPart = body["contents"]!!.jsonArray[1].jsonObject["parts"]!!.jsonArray[0].jsonObject
+        assertFalse(fcPart.containsKey("thoughtSignature"))
+    }
+
     // ── Web search grounding ────────────────────────────────────────────
 
     @Test


### PR DESCRIPTION
Two follow-up fixes from issues #22 and #24 (reported on build 12).

## #22 — Gemini `thought_signature` HTTP 400
The coach broke on the new default model (`gemini-flash-latest` → Gemini 3.x, a *thinking* model):

> Coach error · HTTP 400: Function call is missing a `thought_signature` in functionCall parts … function call `default_api:get_daily_summary`, position 3.

**Cause:** Gemini 3.x attaches an encrypted `thoughtSignature` to `functionCall`/text response parts. Per Google's docs, a client managing its own history must *resend every model-generated part exactly as received, including the signature*. `GeminiClient.ingestResponse()` rebuilt the model turn keeping only `name`+`args`, dropping the signature — so the tool-response turn replayed by `appendContinuation()` was rejected. (Gemini 2.5 didn't enforce this, which is why it only surfaced after PR #23 bumped the default model.)

**Fix:** carry `thoughtSignature` through verbatim on every reconstructed part (functionCall *and* final text). ~6 lines. Added `GeminiClientTest` coverage for the round-trip — signature preserved when present, key absent when the model doesn't send one (2.5 compatibility).

## #24 — Activity tile clips the calories row
The Today `ActivityTile` renders three metrics (steps / distance / calories) at `22.sp` inside a fixed-height (168 dp) tile; the third value overflowed and clipped the calories row.

**Fix:** shrink the value to `16.sp` with tight line heights and disable `includeFontPadding` (Compose's default adds several dp per line), so all three fit with margin. **Verified on-device** — STEPS / MI / CAL now all render fully.

## Verification
- `./gradlew testDebugUnitTest --tests "com.pulseloop.coach.gemini.GeminiClientTest"` green (incl. 2 new tests).
- `compileDebugKotlin` clean.
- Activity tile confirmed on a Pixel 8 (debug build, demo data).

Closes #22
Closes #24