### PR TITLE
fix(colmi): correct sleep big-data request + drop unsupported BP/blood-sugar stages

### DIFF
--- a/app/src/main/java/com/pulseloop/ring/ColmiDecoder.kt
+++ b/app/src/main/java/com/pulseloop/ring/ColmiDecoder.kt
@@ -8,6 +8,9 @@ import java.time.temporal.ChronoUnit
 /** Ring-reported all-day HR config from a `0x16` auto-HR pref read reply. */
 data class ColmiAutoHRReadout(val enabled: Boolean, val intervalMinutes: Int)
 
+/** Capability bits from the 0x3C device-support reply (see [ColmiDecoder.decodeDeviceSupport]). */
+data class ColmiDeviceSupport(val supportsBlePair: Boolean, val supportsIntervalTemp: Boolean)
+
 /**
  * Ported from [ColmiDecoder] in ColmiDecoder.swift.
  * Decodes Colmi frames into shared [RingDecodedEvent]s. Two channels:
@@ -109,60 +112,73 @@ object ColmiDecoder {
         return data[1].toInt() and 0xFF
     }
 
+    /**
+     * [slotMinutes] is the sampling cadence reported by the day's packet 0 (HR: default 5,
+     * stress/HRV: default 30) — the engine captures it per stage and passes it through; QRing
+     * reads the same byte (`range`) in its rsp classes. Hardcoding it compressed history for
+     * any user-configured interval ≠ default.
+     */
     fun decodeHistory(
-        data: ByteArray, day: LocalDate, now: Instant = Instant.now(), zone: ZoneId = ZoneId.systemDefault()
+        data: ByteArray, day: LocalDate, now: Instant = Instant.now(),
+        zone: ZoneId = ZoneId.systemDefault(), slotMinutes: Int? = null
     ): List<RingDecodedEvent> {
         val packet = ColmiPacket.validating(data) ?: return emptyList()
         val v = packet.bytes.map { it.toUByte() }
         return when (v[0]) {
-            ColmiCommandID.SYNC_HEART_RATE -> decodeHRHistory(v, day, zone)
-            ColmiCommandID.SYNC_STRESS -> decodeStressHistory(v, day, zone)
-            ColmiCommandID.SYNC_HRV -> decodeHRVHistory(v, day, zone)
+            ColmiCommandID.SYNC_HEART_RATE -> decodeHRHistory(v, day, zone, slotMinutes ?: 5)
+            ColmiCommandID.SYNC_STRESS -> decodeStressHistory(v, day, zone, slotMinutes ?: 30)
+            ColmiCommandID.SYNC_HRV -> decodeHRVHistory(v, day, zone, slotMinutes ?: 30)
             ColmiCommandID.SYNC_ACTIVITY -> decodeActivityHistory(v, zone, now)
             else -> emptyList()
         }
     }
 
-    private fun decodeHRHistory(v: List<UByte>, day: LocalDate, zone: ZoneId): List<RingDecodedEvent> {
+    private fun decodeHRHistory(
+        v: List<UByte>, day: LocalDate, zone: ZoneId, slotMin: Int
+    ): List<RingDecodedEvent> {
         val packetNr = v[1].toInt()
         if (packetNr == 0xFF || packetNr == 0) return emptyList()
         val startIndex = if (packetNr == 1) 6 else 2
         val base = day.atStartOfDay(zone)
-        val minutesInPrevious = if (packetNr > 1) 9 * 5 + (packetNr - 2) * 13 * 5 else 0
+        val minutesInPrevious = if (packetNr > 1) (9 + (packetNr - 2) * 13) * slotMin else 0
         return (startIndex until v.size - 1).mapNotNull { i ->
             val bpm = v[i].toInt()
             if (bpm == 0) return@mapNotNull null
-            val ts = base.plusMinutes((minutesInPrevious + (i - startIndex) * 5).toLong()).toInstant()
+            val ts = base.plusMinutes((minutesInPrevious + (i - startIndex) * slotMin).toLong()).toInstant()
             RingDecodedEvent.HistoryMeasurement(
                 kind_field = MeasurementKind.HEART_RATE, value = bpm.toDouble(), _timestamp = ts
             )
         }
     }
 
-    private fun decodeStressHistory(v: List<UByte>, day: LocalDate, zone: ZoneId): List<RingDecodedEvent> {
+    private fun decodeStressHistory(
+        v: List<UByte>, day: LocalDate, zone: ZoneId, slotMin: Int
+    ): List<RingDecodedEvent> {
         val packetNr = v[1].toInt()
         if (packetNr == 0xFF || packetNr == 0) return emptyList()
         val startIndex = if (packetNr == 1) 3 else 2
         val base = day.atStartOfDay(zone)
-        val minutesInPrevious = if (packetNr > 1) 12 * 30 + (packetNr - 2) * 13 * 30 else 0
+        val minutesInPrevious = if (packetNr > 1) (12 + (packetNr - 2) * 13) * slotMin else 0
         return (startIndex until v.size - 1).mapNotNull { i ->
             val stress = v[i].toInt()
             if (stress == 0) return@mapNotNull null
-            val ts = base.plusMinutes((minutesInPrevious + (i - startIndex) * 30).toLong()).toInstant()
+            val ts = base.plusMinutes((minutesInPrevious + (i - startIndex) * slotMin).toLong()).toInstant()
             RingDecodedEvent.StressSample(value = stress, _timestamp = ts)
         }
     }
 
-    private fun decodeHRVHistory(v: List<UByte>, day: LocalDate, zone: ZoneId): List<RingDecodedEvent> {
+    private fun decodeHRVHistory(
+        v: List<UByte>, day: LocalDate, zone: ZoneId, slotMin: Int
+    ): List<RingDecodedEvent> {
         val packetNr = v[1].toInt()
         if (packetNr == 0xFF || packetNr == 0) return emptyList()
         val startIndex = if (packetNr == 1) 3 else 2
         val base = day.atStartOfDay(zone)
-        val minutesInPrevious = if (packetNr > 1) 12 * 30 + (packetNr - 2) * 13 * 30 else 0
+        val minutesInPrevious = if (packetNr > 1) (12 + (packetNr - 2) * 13) * slotMin else 0
         return (startIndex until v.size - 1).mapNotNull { i ->
             val hrv = v[i].toInt()
             if (hrv == 0) return@mapNotNull null
-            val ts = base.plusMinutes((minutesInPrevious + (i - startIndex) * 30).toLong()).toInstant()
+            val ts = base.plusMinutes((minutesInPrevious + (i - startIndex) * slotMin).toLong()).toInstant()
             RingDecodedEvent.HrvSample(value = hrv, _timestamp = ts)
         }
     }
@@ -227,17 +243,25 @@ object ColmiDecoder {
     }
 
     /**
-     * Decode a `0x3C` device-support reply and return whether the ring wants an OS-level bond.
-     * Frame layout mirrors QRing's `DeviceSupportFunctionRsp.acceptData`: opcode at `[0]`, the
-     * first feature byte at `[1]`, where bit 3 (`0x08`) is `supportBlePair`. Returns null for any
-     * frame that isn't a device-support reply — callers treat null as "not a bond signal", so a
-     * wrong guess degrades to today's no-bond behaviour rather than misbehaving.
+     * Decode a `0x3C` device-support reply into the capability bits we act on.
+     *
+     * OFFSET NOTE: QRing's `QCDataParser` strips the opcode (and checksum) before
+     * `DeviceSupportFunctionRsp.acceptData` runs, so the rsp class's `bArr[N]` is FULL-frame
+     * byte `N+1`. `supportBlePair` = rsp `bArr[1] & 0x08` → full-frame `[2]`;
+     * `supportIntervalTemp` = rsp `bArr[8] & 0x80` → full-frame `[9]`. The original port read
+     * the bond bit from full-frame `[1]` — a byte QRing never parses.
+     *
+     * Returns null for any frame that isn't a device-support reply — callers treat null as
+     * "no capability signal", so a wrong guess degrades to no-bond/legacy-path behaviour.
      */
-    fun decodeDeviceSupport(data: ByteArray): Boolean? {
+    fun decodeDeviceSupport(data: ByteArray): ColmiDeviceSupport? {
         val packet = ColmiPacket.validating(data) ?: return null
         val v = packet.bytes.map { it.toUByte() }
         if (v[0] != ColmiCommandID.DEVICE_SUPPORT) return null
-        return (v[1].toInt() and 0x08) != 0
+        return ColmiDeviceSupport(
+            supportsBlePair = (v[2].toInt() and 0x08) != 0,
+            supportsIntervalTemp = (v[9].toInt() and 0x80) != 0,
+        )
     }
 
     // MARK: Big-data (V2)
@@ -252,34 +276,77 @@ object ColmiDecoder {
         return when (v[1]) {
             ColmiCommandID.BIG_DATA_SPO2 -> decodeSpo2(data, zone)
             ColmiCommandID.BIG_DATA_SLEEP -> decodeSleep(data, zone)
+            // Nap/lunch sleep (action 62): emitted spontaneously alongside the action-39 reply on
+            // rings with nap support. Same day-record layout as action 39 (QRing's
+            // parseDaySleepLunch reads the identical [daysAgo][len][start u16][end u16][pairs…]
+            // structure), so the regular sleep decoder handles it.
+            ColmiCommandID.BIG_DATA_SLEEP_LUNCH -> decodeSleep(data, zone)
             ColmiCommandID.BIG_DATA_TEMPERATURE -> decodeTemperature(data, zone)
-            ColmiCommandID.BIG_DATA_BLOOD_SUGAR -> decodeBloodSugar(data, zone)
+            // Blood sugar (0x47): Colmi rings don't support it and nothing requests it; the old
+            // parser here was a wrong-format guess (QRing uses SpO2-style 49-byte blocks), so a
+            // re-emitted frame would have decoded into garbage measurements. Ignore instead.
+            ColmiCommandID.BIG_DATA_BLOOD_SUGAR -> emptyList()
             else -> listOf(RingDecodedEvent.Unknown(commandId = v[1], raw = data))
         }
+    }
+
+    /**
+     * Interval temperature (action 119) — one packet of a day's series. Header (full frame):
+     * `[6]`=dayIndex, `[7]`=interval minutes, `[8]`=packetCount, `[9]`=packetIndex, then u16 LE
+     * samples in centi-°C (QRing `LargeDataHandler.getIntervalTemperature`). [sampleOffset] is
+     * the count of samples already decoded from this day's earlier packets — the caller
+     * (ColmiDriver) accumulates it, since slot position is cumulative across packets.
+     */
+    fun decodeIntervalTemperature(
+        data: ByteArray, sampleOffset: Int, zone: ZoneId = ZoneId.systemDefault()
+    ): List<RingDecodedEvent> {
+        if (data.size < 10) return emptyList()
+        val v = data.map { it.toUByte() }
+        val dayIndex = v[6].toInt()
+        val interval = v[7].toInt().takeIf { it > 0 } ?: 30
+        val dayStart = LocalDate.now(zone).minusDays(dayIndex.toLong()).atStartOfDay(zone)
+        val events = mutableListOf<RingDecodedEvent>()
+        var index = 10
+        var slot = sampleOffset
+        while (index + 1 < data.size) {
+            val raw = ColmiBytes.u16(v[index], v[index + 1])
+            index += 2
+            if (raw > 0) {
+                events.add(RingDecodedEvent.TemperatureSample(
+                    celsius = raw.toDouble() / 100.0,
+                    _timestamp = dayStart.plusMinutes((slot * interval).toLong()).toInstant()
+                ))
+            }
+            slot++
+        }
+        return events
     }
 
     private fun decodeSpo2(data: ByteArray, zone: ZoneId): List<RingDecodedEvent> {
         val v = data.map { it.toUByte() }
         val length = ColmiBytes.u16(v[2], v[3])
-        var index = 6
-        val events = mutableListOf<RingDecodedEvent>()
-        var daysAgo = -1
+        // QRing (BloodOxygenRepository): payload = length/49 blocks of [daysAgo][24 hourly
+        // (min,max) byte pairs], every block processed regardless of day order. The old loop
+        // stopped at the first daysAgo==0 block, dropping older days whenever today's block
+        // wasn't last. The (min+max)/2 collapse below is an intentional app simplification.
+        val blocks = length / 49
         val today = LocalDate.now(zone)
-        while (daysAgo != 0 && index - 6 < length && index < v.size) {
-            daysAgo = v[index].toInt(); index++
+        val events = mutableListOf<RingDecodedEvent>()
+        for (b in 0 until blocks) {
+            val base = 6 + b * 49
+            if (base + 49 > v.size) break
+            val daysAgo = v[base].toInt()
             val dayStart = today.minusDays(daysAgo.toLong())
             for (hour in 0..23) {
-                if (index + 1 >= v.size) break
-                val lo = v[index].toInt(); index++
-                val hi = v[index].toInt(); index++
+                val lo = v[base + 1 + hour * 2].toInt()
+                val hi = v[base + 2 + hour * 2].toInt()
                 if (lo > 0 && hi > 0) {
-                    val value = ((lo + hi).toDouble() / 2.0)
                     val ts = dayStart.atTime(hour, 0).atZone(zone).toInstant()
                     events.add(RingDecodedEvent.HistoryMeasurement(
-                        kind_field = MeasurementKind.SPO2, value = value, _timestamp = ts
+                        kind_field = MeasurementKind.SPO2,
+                        value = (lo + hi).toDouble() / 2.0, _timestamp = ts
                     ))
                 }
-                if (index - 6 >= length) break
             }
         }
         return events
@@ -288,32 +355,28 @@ object ColmiDecoder {
     private fun decodeTemperature(data: ByteArray, zone: ZoneId): List<RingDecodedEvent> {
         val v = data.map { it.toUByte() }
         val length = ColmiBytes.u16(v[2], v[3])
-        if (length < 50) return emptyList()
+        if (length < 2) return emptyList()
+        // QRing (DataHelper.parseTemperature): each day-block is [daysAgo][timeSpan][values…]
+        // with 1440/timeSpan single-byte samples at raw/10 + 20 °C. The old decoder skipped
+        // timeSpan as "one unknown byte" and hardcoded the 30-minute :00/:30 grid, compressing
+        // any day whose firmware cadence differs; it also stopped at the first daysAgo==0 block.
         var index = 6
         val events = mutableListOf<RingDecodedEvent>()
-        var daysAgo = -1
         val today = LocalDate.now(zone)
-        while (daysAgo != 0 && index - 6 < length && index < v.size) {
-            daysAgo = v[index].toInt(); index++
-            index++ // skip one unknown byte
-            val dayStart = today.minusDays(daysAgo.toLong())
-            for (hour in 0..23) {
-                if (index + 1 >= v.size) break
-                val t00 = v[index].toInt(); index++
-                val t30 = v[index].toInt(); index++
-                if (t00 > 0) {
+        while (index - 6 < length && index + 1 < v.size) {
+            val daysAgo = v[index].toInt(); index++
+            val timeSpan = v[index].toInt().takeIf { it in 1..1440 } ?: 30; index++
+            val samples = 1440 / timeSpan
+            val dayStart = today.minusDays(daysAgo.toLong()).atStartOfDay(zone)
+            for (s in 0 until samples) {
+                if (index >= v.size || index - 6 >= length) break
+                val raw = v[index].toInt(); index++
+                if (raw > 0) {
                     events.add(RingDecodedEvent.TemperatureSample(
-                        celsius = t00.toDouble() / 10.0 + 20.0,
-                        _timestamp = dayStart.atTime(hour, 0).atZone(zone).toInstant()
+                        celsius = raw.toDouble() / 10.0 + 20.0,
+                        _timestamp = dayStart.plusMinutes((s * timeSpan).toLong()).toInstant()
                     ))
                 }
-                if (t30 > 0) {
-                    events.add(RingDecodedEvent.TemperatureSample(
-                        celsius = t30.toDouble() / 10.0 + 20.0,
-                        _timestamp = dayStart.atTime(hour, 30).atZone(zone).toInstant()
-                    ))
-                }
-                if (index - 6 >= length) break
             }
         }
         return events
@@ -364,38 +427,4 @@ object ColmiDecoder {
         else -> SleepStage.UNKNOWN
     }
 
-    /**
-     * Decode blood sugar big-data response.
-     * Format (best-guess, validate with real ring): same structure as temperature —
-     * per-day entries with day index + hourly readings. Each reading is mg/dL × 10.
-     */
-    private fun decodeBloodSugar(data: ByteArray, zone: ZoneId): List<RingDecodedEvent> {
-        val v = data.map { it.toUByte() }
-        val length = ColmiBytes.u16(v[2], v[3])
-        if (length < 2) return emptyList()
-        var index = 6
-        val events = mutableListOf<RingDecodedEvent>()
-        var daysAgo = -1
-        val today = LocalDate.now(zone)
-        while (daysAgo != 0 && index - 6 < length && index < v.size) {
-            daysAgo = v[index].toInt(); index++
-            index++ // skip unknown byte
-            val dayStart = today.minusDays(daysAgo.toLong())
-            for (hour in 0..23) {
-                if (index + 1 >= v.size) break
-                val hi = v[index].toInt(); index++
-                val lo = v[index].toInt(); index++
-                val raw = ((hi shl 8) or lo)
-                if (raw > 0) {
-                    events.add(RingDecodedEvent.HistoryMeasurement(
-                        kind_field = MeasurementKind.BLOOD_SUGAR,
-                        value = raw.toDouble() / 10.0,
-                        _timestamp = dayStart.atTime(hour, 0).atZone(zone).toInstant()
-                    ))
-                }
-                if (index - 6 >= length) break
-            }
-        }
-        return events
-    }
 }

--- a/app/src/main/java/com/pulseloop/ring/ColmiDriver.kt
+++ b/app/src/main/java/com/pulseloop/ring/ColmiDriver.kt
@@ -61,19 +61,14 @@ class ColmiDriver(private val writer: RingCommandWriter) : WearableDriver {
             }
             return accumulate(data)
         }
-        // Mid-transfer: a chunk that is itself an exactly-complete 0xBC frame is a distinct
-        // message (e.g. a whole sleep frame arriving while an SpO2 transfer streams) — process
-        // it standalone without touching the pending buffer. Anything else, INCLUDING a chunk
-        // that merely starts with 0xBC, is a continuation: ATT chunk boundaries are arbitrary,
-        // so a payload byte can collide with the header magic, and restarting on it corrupted
-        // the transfer (QRing's LargeDataParser appends unconditionally while `intact` is false).
-        if (isSelfCompleteBigDataFrame(data)) return completeAndDecode(data)
+        // Mid-transfer: append EVERY chunk, including one that starts with 0xBC. ATT chunk
+        // boundaries are arbitrary, so a payload byte can collide with the header magic;
+        // treating such a chunk as a new frame corrupted the transfer. This matches QRing's
+        // LargeDataParser, which appends unconditionally while `intact` is false. Rings stream
+        // one big-data reply at a time (QRing can't handle interleaving either), so there is no
+        // interleaved-frame case to special-case.
         return accumulate(pending + data)
     }
-
-    private fun isSelfCompleteBigDataFrame(data: ByteArray): Boolean =
-        data.size >= 6 && data[0].toUByte() == ColmiCommandID.BIG_DATA_V2 &&
-            data.size == ColmiBytes.u16(data[2].toUByte(), data[3].toUByte()) + 6
 
     private fun accumulate(buffer: ByteArray): List<RingDecodedEvent> {
         val expectedLength = ColmiBytes.u16(buffer[2].toUByte(), buffer[3].toUByte())

--- a/app/src/main/java/com/pulseloop/ring/ColmiDriver.kt
+++ b/app/src/main/java/com/pulseloop/ring/ColmiDriver.kt
@@ -8,9 +8,16 @@ class ColmiDriver(private val writer: RingCommandWriter) : WearableDriver {
     private val decoder = ColmiDecoder
     private val engine: ColmiSyncEngine = ColmiSyncEngine(writer, decoder)
 
-    // Big-data reassembly state
-    private val bigDataBuffers = mutableMapOf<UByte, ByteArray>()
-    private var activeBigDataType: UByte? = null
+    // Big-data reassembly state: one in-flight transfer, QRing LargeDataParser semantics.
+    // While a transfer is incomplete EVERY notify chunk is appended — including one that
+    // happens to start with 0xBC, since ATT chunk boundaries are arbitrary and a payload
+    // byte can collide with the header magic. A new header is only accepted when idle.
+    // (Rings stream one big-data reply at a time; QRing has never handled interleaving.)
+    private var bigDataBuffer: ByteArray? = null
+
+    /** Samples already decoded from earlier packets of the current interval-temperature day —
+     *  slot position is cumulative across a day's packets (see decodeIntervalTemperature). */
+    private var intervalTempSampleOffset = 0
 
     // BLE topology
     override val serviceUUIDs = listOf(ColmiUUIDs.SERVICE_V1, ColmiUUIDs.SERVICE_V2)
@@ -41,42 +48,55 @@ class ColmiDriver(private val writer: RingCommandWriter) : WearableDriver {
         if (ColmiSyncEngine.isHistoryOpcode(op)) {
             return engine.handleHistoryFrame(data)
         }
-        val events = decoder.decodeNormal(data)
-        if (data.isNotEmpty() && data[0].toUByte() == ColmiCommandID.REALTIME_HEART_RATE) {
-            engine.observedRealtimeHeartRate()
-        }
-        return events
+        return decoder.decodeNormal(data)
     }
 
     private fun ingestBigData(data: ByteArray): List<RingDecodedEvent> {
-        val type: UByte
-        if (data.isNotEmpty() && data[0].toUByte() == ColmiCommandID.BIG_DATA_V2) {
-            val v = data.map { it.toUByte() }
-            if (v.size < 4) return emptyList()
-            type = v[1]
-            bigDataBuffers[type] = data
-        } else if (activeBigDataType != null && bigDataBuffers.containsKey(activeBigDataType)) {
-            type = activeBigDataType!!
-            bigDataBuffers[type] = bigDataBuffers[type]!! + data
-        } else {
-            return listOf(RingDecodedEvent.Unknown(
-                commandId = if (data.isNotEmpty()) data[0].toUByte() else 0u, raw = data
-            ))
+        val pending = bigDataBuffer
+        if (pending == null) {
+            if (data.size < 6 || data[0].toUByte() != ColmiCommandID.BIG_DATA_V2) {
+                return listOf(RingDecodedEvent.Unknown(
+                    commandId = if (data.isNotEmpty()) data[0].toUByte() else 0u, raw = data
+                ))
+            }
+            return accumulate(data)
         }
+        // Mid-transfer: a chunk that is itself an exactly-complete 0xBC frame is a distinct
+        // message (e.g. a whole sleep frame arriving while an SpO2 transfer streams) — process
+        // it standalone without touching the pending buffer. Anything else, INCLUDING a chunk
+        // that merely starts with 0xBC, is a continuation: ATT chunk boundaries are arbitrary,
+        // so a payload byte can collide with the header magic, and restarting on it corrupted
+        // the transfer (QRing's LargeDataParser appends unconditionally while `intact` is false).
+        if (isSelfCompleteBigDataFrame(data)) return completeAndDecode(data)
+        return accumulate(pending + data)
+    }
 
-        val buffer = bigDataBuffers[type] ?: return emptyList()
-        val bytes = buffer.map { it.toUByte() }
-        if (bytes.size < 4) return emptyList()
-        val expectedLength = ColmiBytes.u16(bytes[2], bytes[3])
+    private fun isSelfCompleteBigDataFrame(data: ByteArray): Boolean =
+        data.size >= 6 && data[0].toUByte() == ColmiCommandID.BIG_DATA_V2 &&
+            data.size == ColmiBytes.u16(data[2].toUByte(), data[3].toUByte()) + 6
+
+    private fun accumulate(buffer: ByteArray): List<RingDecodedEvent> {
+        val expectedLength = ColmiBytes.u16(buffer[2].toUByte(), buffer[3].toUByte())
         if (buffer.size < expectedLength + 6) {
-            activeBigDataType = type
+            bigDataBuffer = buffer
             return emptyList()
         }
+        bigDataBuffer = null
+        return completeAndDecode(buffer)
+    }
 
-        bigDataBuffers.remove(type)
-        activeBigDataType = bigDataBuffers.keys.firstOrNull()
-        val events = decoder.decodeBigData(buffer)
-        engine.handleBigDataComplete(type = type)
+    private fun completeAndDecode(buffer: ByteArray): List<RingDecodedEvent> {
+        val type = buffer[1].toUByte()
+        val events = if (type == ColmiCommandID.BIG_DATA_INTERVAL_TEMPERATURE) {
+            val packetIndex = if (buffer.size > 9) buffer[9].toInt() and 0xFF else 0
+            if (packetIndex == 0) intervalTempSampleOffset = 0
+            val decoded = decoder.decodeIntervalTemperature(buffer, sampleOffset = intervalTempSampleOffset)
+            intervalTempSampleOffset += ((buffer.size - 10).coerceAtLeast(0)) / 2
+            decoded
+        } else {
+            decoder.decodeBigData(buffer)
+        }
+        engine.handleBigDataComplete(type = type, data = buffer)
         return events
     }
 

--- a/app/src/main/java/com/pulseloop/ring/ColmiEncoder.kt
+++ b/app/src/main/java/com/pulseloop/ring/ColmiEncoder.kt
@@ -183,7 +183,12 @@ object ColmiEncoder {
 
     fun bigDataSleep(): ByteArray = byteArrayOf(
         ColmiCommandID.BIG_DATA_V2.toByte(), ColmiCommandID.BIG_DATA_SLEEP.toByte(),
-        0x01, 0x00, 0xFF.toByte(), 0x00, 0xFF.toByte(),
+        // New_Sleep_Protocol (big-data action 39) requires a 2-byte payload [0xFF, 0x01] —
+        // 0xFF = "all history", 0x01 = protocol version — framed with its real CRC16/MODBUS.
+        // The old 1-byte [0xFF] payload (bc 27 01 00 ff 00 ff) is silently ignored by the ring,
+        // so sleep never synced. Frame: len=2 (LE), CRC16([0xFF,0x01])=0x8081 (LE 81 80), FF 01.
+        // Verified against QRing's LargeDataHandler.addHeader(39, {0xFF, 0x01}) + CRC16.
+        0x02, 0x00, 0x81.toByte(), 0x80.toByte(), 0xFF.toByte(), 0x01,
     )
 
     fun bigDataTemperature(): ByteArray = byteArrayOf(

--- a/app/src/main/java/com/pulseloop/ring/ColmiEncoder.kt
+++ b/app/src/main/java/com/pulseloop/ring/ColmiEncoder.kt
@@ -196,26 +196,10 @@ object ColmiEncoder {
         0x01, 0x00, 0x3E, 0x81.toByte(), 0x02,
     )
 
-    fun bigDataBloodSugar(): ByteArray = byteArrayOf(
-        ColmiCommandID.BIG_DATA_V2.toByte(), ColmiCommandID.BIG_DATA_BLOOD_SUGAR.toByte(),
-        0x01, 0x00, 0xFF.toByte(), 0x00, 0xFF.toByte(),
-    )
-
-    /** Request BP history from the ring. [fromUnix] = starting epoch (0 = all available). */
-    fun syncBp(fromUnix: Int = 0): ByteArray {
-        val ts = fromUnix.toUInt()
-        return byteArrayOf(
-            ColmiCommandID.BP_READ.toByte(),
-            (ts and 0xFFu).toByte(),
-            ((ts shr 8) and 0xFFu).toByte(),
-            ((ts shr 16) and 0xFFu).toByte(),
-            ((ts shr 24) and 0xFFu).toByte(),
-            0x00, 0x32,  // count = 50
-        )
-    }
-
-    fun confirmBp(success: Boolean = true): ByteArray =
-        byteArrayOf(ColmiCommandID.BP_CONFIRM.toByte(), if (success) 0x00 else 0xFF.toByte())
+    // No BP / blood-sugar request builders: Colmi rings support neither (see
+    // ColmiCoordinator.capabilities). The decoder keeps its defensive parsers for
+    // stray 0x14 / big-data 0x47 frames, but nothing must ever request them —
+    // unsupported requests trigger frame re-emission storms (PR #26).
 }
 
 /**

--- a/app/src/main/java/com/pulseloop/ring/ColmiEncoder.kt
+++ b/app/src/main/java/com/pulseloop/ring/ColmiEncoder.kt
@@ -26,6 +26,9 @@ object ColmiEncoder {
             bcd(zdt.hour).toByte(),
             bcd(zdt.minute).toByte(),
             bcd(zdt.second).toByte(),
+            // Language byte (QRing SetTimeReq subData[6]): 0 = zh_CN, 1 = en. Zero-padding
+            // used to select Chinese on display-equipped Colmi-family devices.
+            if (java.util.Locale.getDefault().language == "zh") 0x00 else 0x01,
         )
     }
 
@@ -38,7 +41,10 @@ object ColmiEncoder {
         0x00,
         if (metric) 0x00 else 0x01,
         gender.toByte(), age.toByte(), heightCm.toByte(), weightKg.toByte(),
-        0x00, 0x00, 0x00,
+        // BP reference 120/90: QRing (TimeFormatReq callers) hardcodes these unconditionally —
+        // firmware may use them as PPG calibration baselines, so never send 0/0. Trailing
+        // HR-warn threshold stays 0 (= alerts off, matching QRing when unset).
+        0x78, 0x5A, 0x00,
     )
 
     fun battery(): ByteArray = byteArrayOf(ColmiCommandID.BATTERY.toByte())
@@ -91,26 +97,34 @@ object ColmiEncoder {
 
     /**
      * Enable/disable all-day temperature monitoring. Mirrors [readTempPref]'s extra `0x03`
-     * framing byte before the write flag. Verified against hardware (`3a 03 02 01` was acked
-     * by a Colmi ring).
+     * framing byte before the write flag, then the **full 6-field record** QRing always sends
+     * (`SugarLipidsSettingReq.getWriteInstance((byte)3, …)`): interval, start, remind-interval,
+     * remind bits, custom-alert byte ((°C×10)−200). Firmware defaults per QRing's
+     * `BloodSugarLipidsSettingRsp`: interval 30 min, start 5, remind 10; alert bits 0 = alerts
+     * off, so the custom byte (38.5 °C) is inert. The old 4-byte `3a 03 02 <en>` form was the
+     * same truncation bug class as the short 0x16 auto-HR write: RT-series firmware ACKs it but
+     * reads interval = 0 and never arms background sampling.
      */
     fun writeTempPref(enabled: Boolean): ByteArray = byteArrayOf(
         ColmiCommandID.AUTO_TEMP_PREF.toByte(), 0x03, ColmiCommandID.PREF_WRITE.toByte(),
         if (enabled) 0x01 else 0x00,
+        30, 5, 10, 0x00, 0xB9.toByte(),
     )
 
     fun readGoals(): ByteArray = byteArrayOf(ColmiCommandID.GOALS.toByte(), ColmiCommandID.PREF_READ.toByte())
 
-    fun manualHeartRate(enable: Boolean = true): ByteArray = if (enable) {
+    fun manualHeartRate(enable: Boolean = true, lastBpm: Int = 0): ByteArray = if (enable) {
         byteArrayOf(ColmiCommandID.MANUAL_HEART_RATE.toByte(), ColmiCommandID.RT_HEART_RATE.toByte())
     } else {
         // Stop MUST use CMD_STOP_REAL_TIME (0x6A). The old [0x69, 0x02] was another
         // CMD_START_REAL_TIME (reading type 2), so the optical sensor never switched off
         // and the ring kept pulsing until it timed out. Mirror the SpO₂ stop frame.
+        // On a successful measurement QRing reports the final reading in byte 2
+        // (stopHeartRate((byte) heartValue)) so the ring's own log records it; 0 = cancelled.
         byteArrayOf(
             ColmiCommandID.REALTIME_STOP.toByte(),
             ColmiCommandID.RT_HEART_RATE.toByte(),
-            0x00, 0x00,
+            lastBpm.coerceIn(0, 255).toByte(), 0x00,
         )
     }
 
@@ -130,7 +144,10 @@ object ColmiEncoder {
         byteArrayOf(
             ColmiCommandID.MANUAL_HEART_RATE.toByte(),
             ColmiCommandID.RT_SPO2.toByte(),
-            ColmiCommandID.RT_ACTION_START.toByte(),
+            // QRing sends BCD(25) = 0x25 as the third byte for every reading type ≥ 3
+            // (StartHeartRateReq.getSimpleReq). colmi_r02_client's Action.START (0x01) works on
+            // R02-class firmware but is a byte the official app never sends; follow QRing.
+            0x25,
         )
     } else {
         byteArrayOf(
@@ -162,7 +179,10 @@ object ColmiEncoder {
         )
     }
 
-    fun syncStress(): ByteArray = byteArrayOf(ColmiCommandID.SYNC_STRESS.toByte())
+    /** Stress history request. QRing (`PressureReq`) pages `[0x37, dayIndex]` over today+6 past
+     *  days; the old bare `[0x37]` (zero padding = day 0) only ever fetched today. */
+    fun syncStress(daysAgo: Int = 0): ByteArray =
+        byteArrayOf(ColmiCommandID.SYNC_STRESS.toByte(), daysAgo.coerceIn(0, 255).toByte())
 
     fun syncHRV(daysAgo: Int): ByteArray {
         val d = daysAgo.coerceIn(0, 255).toUInt()
@@ -175,25 +195,57 @@ object ColmiEncoder {
         )
     }
 
-    // Big-data requests
-    fun bigDataSpo2(): ByteArray = byteArrayOf(
-        ColmiCommandID.BIG_DATA_V2.toByte(), ColmiCommandID.BIG_DATA_SPO2.toByte(),
-        0x01, 0x00, 0xFF.toByte(), 0x00, 0xFF.toByte(),
-    )
+    // Big-data requests (0xBC family). Frame = [0xBC, action, len u16 LE, CRC16 u16 LE, payload],
+    // exactly QRing's LargeDataHandler.addHeader(action, payload) with CRC16/MODBUS over the
+    // payload (init 0xFFFF, poly 0xA001, LE on the wire).
+    private fun crc16Modbus(payload: ByteArray): Int {
+        var crc = 0xFFFF
+        for (b in payload) {
+            crc = crc xor (b.toInt() and 0xFF)
+            repeat(8) { crc = if (crc and 1 != 0) (crc ushr 1) xor 0xA001 else crc ushr 1 }
+        }
+        return crc
+    }
 
-    fun bigDataSleep(): ByteArray = byteArrayOf(
-        ColmiCommandID.BIG_DATA_V2.toByte(), ColmiCommandID.BIG_DATA_SLEEP.toByte(),
-        // New_Sleep_Protocol (big-data action 39) requires a 2-byte payload [0xFF, 0x01] —
-        // 0xFF = "all history", 0x01 = protocol version — framed with its real CRC16/MODBUS.
-        // The old 1-byte [0xFF] payload (bc 27 01 00 ff 00 ff) is silently ignored by the ring,
-        // so sleep never synced. Frame: len=2 (LE), CRC16([0xFF,0x01])=0x8081 (LE 81 80), FF 01.
-        // Verified against QRing's LargeDataHandler.addHeader(39, {0xFF, 0x01}) + CRC16.
-        0x02, 0x00, 0x81.toByte(), 0x80.toByte(), 0xFF.toByte(), 0x01,
-    )
+    private fun bigDataRequest(action: UByte, payload: ByteArray): ByteArray {
+        val crc = crc16Modbus(payload)
+        return byteArrayOf(
+            ColmiCommandID.BIG_DATA_V2.toByte(), action.toByte(),
+            (payload.size and 0xFF).toByte(), ((payload.size shr 8) and 0xFF).toByte(),
+            (crc and 0xFF).toByte(), ((crc shr 8) and 0xFF).toByte(),
+        ) + payload
+    }
 
-    fun bigDataTemperature(): ByteArray = byteArrayOf(
-        ColmiCommandID.BIG_DATA_V2.toByte(), ColmiCommandID.BIG_DATA_TEMPERATURE.toByte(),
-        0x01, 0x00, 0x3E, 0x81.toByte(), 0x02,
+    fun bigDataSpo2(): ByteArray =
+        bigDataRequest(ColmiCommandID.BIG_DATA_SPO2, byteArrayOf(0xFF.toByte()))
+
+    /**
+     * New_Sleep_Protocol (big-data action 39): 2-byte payload [0xFF, 0x01] — 0xFF = "all
+     * history", 0x01 = protocol version. The pre-fix 1-byte [0xFF] payload
+     * (bc 27 01 00 ff 00 ff) is silently ignored by the ring, so sleep never synced.
+     * On the wire: bc 27 02 00 81 80 ff 01 ≡ QRing's addHeader(39, {0xFF, 0x01}).
+     */
+    fun bigDataSleep(): ByteArray =
+        bigDataRequest(ColmiCommandID.BIG_DATA_SLEEP, byteArrayOf(0xFF.toByte(), 0x01))
+
+    /**
+     * Legacy temperature series (action 37); payload = day count. QRing requests 6 days for a
+     * first/stale sync and 2 once today has synced — always ask for 6 so backfill after a gap
+     * isn't capped at two days. Rings whose 0x3C reply sets supportIntervalTemp use
+     * [bigDataIntervalTemperature] instead; QRing never sends action 37 to those.
+     */
+    fun bigDataTemperature(days: Int = 6): ByteArray =
+        bigDataRequest(ColmiCommandID.BIG_DATA_TEMPERATURE, byteArrayOf(days.coerceIn(1, 255).toByte()))
+
+    /**
+     * Interval temperature history (action 119): payload [dayIndex, packetIndex]. A day's series
+     * can span several packets; the reply header carries packetCount/packetIndex and the app
+     * must re-request packetIndex+1 until the last one (QRing LargeDataHandler §119) —
+     * [ColmiSyncEngine.handleBigDataComplete] drives that continuation.
+     */
+    fun bigDataIntervalTemperature(daysAgo: Int, packetIndex: Int): ByteArray = bigDataRequest(
+        ColmiCommandID.BIG_DATA_INTERVAL_TEMPERATURE,
+        byteArrayOf(daysAgo.coerceIn(0, 255).toByte(), packetIndex.coerceIn(0, 255).toByte()),
     )
 
     // No BP / blood-sugar request builders: Colmi rings support neither (see

--- a/app/src/main/java/com/pulseloop/ring/ColmiProtocol.kt
+++ b/app/src/main/java/com/pulseloop/ring/ColmiProtocol.kt
@@ -70,6 +70,12 @@ object ColmiCommandID {
     const val BIG_DATA_TEMPERATURE: UByte = 0x25u
     const val BIG_DATA_SLEEP: UByte = 0x27u
     const val BIG_DATA_SPO2: UByte = 0x2Au
+    /** Nap/lunch sleep (QRing action 62). Never requested — rings with nap support emit it
+     *  spontaneously alongside the action-39 reply to [ColmiEncoder.bigDataSleep]. */
+    const val BIG_DATA_SLEEP_LUNCH: UByte = 0x3Eu
+    /** Interval temperature history (QRing action 119) — the modern per-day, packet-indexed
+     *  path used instead of [BIG_DATA_TEMPERATURE] when the 0x3C reply sets supportIntervalTemp. */
+    const val BIG_DATA_INTERVAL_TEMPERATURE: UByte = 0x77u
 
     // Sleep stage types
     const val SLEEP_LIGHT: UByte = 0x02u

--- a/app/src/main/java/com/pulseloop/ring/ColmiSyncEngine.kt
+++ b/app/src/main/java/com/pulseloop/ring/ColmiSyncEngine.kt
@@ -61,6 +61,12 @@ class ColmiSyncEngine(
      *  (action 119) instead of the legacy action 37 that such firmware may not answer. */
     private var supportsIntervalTemp = false
 
+    /** Highest interval-temperature packet index seen for the current day, or -1 at the start of
+     *  a day. Guards the action-119 continuation against firmware that never advances the index
+     *  (see [handleBigDataComplete]) — a re-request loop would otherwise re-arm the watchdog
+     *  forever, the same unbounded-write failure this PR fixes elsewhere. */
+    private var lastIntervalTempPacket = -1
+
     /** A standalone sleep-only request is outstanding (see [syncSleepNow]). Set true when we fire
      *  `bigDataSleep()` outside the staged history sync; its big-data completion clears it and
      *  must NOT advance the pipeline into HRV. Volatile: set on Main, read on the notify thread. */
@@ -292,7 +298,15 @@ class ColmiSyncEngine(
                     val echo = v[2].toLong() or (v[3].toLong() shl 8) or
                         (v[4].toLong() shl 16) or (v[5].toLong() shl 24)
                     if (echo > 0) {
-                        syncDay = Instant.ofEpochSecond(echo).atZone(ZoneOffset.UTC).toLocalDate()
+                        val candidate = Instant.ofEpochSecond(echo).atZone(ZoneOffset.UTC).toLocalDate()
+                        // Trust the echo only within ±2 days of the requested day: it corrects the
+                        // ≤1-day tz mis-attribution it was added for, but a garbage ring clock
+                        // (e.g. an all-0xFF echo → year 2106) would otherwise stamp HR samples far
+                        // in the future — decodeHRHistory has no time clamp of its own.
+                        if (!candidate.isBefore(syncDay.minusDays(2)) &&
+                            !candidate.isAfter(syncDay.plusDays(2))) {
+                            syncDay = candidate
+                        }
                     }
                 }
                 else -> {
@@ -346,13 +360,21 @@ class ColmiSyncEngine(
                 // day (0..6) and finish after the oldest.
                 val packetCount = data?.getOrNull(8)?.toInt()?.and(0xFF) ?: 0
                 val packetIndex = data?.getOrNull(9)?.toInt()?.and(0xFF) ?: 0
+                // Progress guard: only continue paging a day while the index strictly advances.
+                // A reply that repeats/regresses the index (misbehaving firmware) would otherwise
+                // make us re-request the same packet forever, each reply re-arming the watchdog so
+                // it never breaks the loop — the request-storm class this PR exists to kill. On a
+                // stalled index we drop to the next day instead.
+                val advanced = packetIndex > lastIntervalTempPacket
+                lastIntervalTempPacket = packetIndex
                 when {
-                    packetCount > 0 && packetIndex < packetCount - 1 -> {
+                    advanced && packetCount > 0 && packetIndex < packetCount - 1 -> {
                         writer?.enqueue(encoder.bigDataIntervalTemperature(daysAgo, packetIndex + 1))
                         armWatchdog()
                     }
                     daysAgo < 6 -> {
                         daysAgo++
+                        lastIntervalTempPacket = -1
                         writer?.enqueue(encoder.bigDataIntervalTemperature(daysAgo, 0))
                         armWatchdog()
                     }
@@ -408,6 +430,7 @@ class ColmiSyncEngine(
         if (supportsIntervalTemp) {
             // Modern path (QRing gates on the same 0x3C bit): per-day interval series, starting
             // at today packet 0; handleBigDataComplete drives packet/day continuation.
+            lastIntervalTempPacket = -1
             writer?.enqueue(encoder.bigDataIntervalTemperature(daysAgo, 0))
         } else {
             writer?.enqueue(encoder.bigDataTemperature())

--- a/app/src/main/java/com/pulseloop/ring/ColmiSyncEngine.kt
+++ b/app/src/main/java/com/pulseloop/ring/ColmiSyncEngine.kt
@@ -265,9 +265,14 @@ class ColmiSyncEngine(
                 stage = Stage.HRV; daysAgo = 0; requestHRV(); armWatchdog()
             }
             ColmiCommandID.BIG_DATA_TEMPERATURE -> {
-                stage = Stage.BLOOD_SUGAR; requestBloodSugar(); armWatchdog()
+                // Temperature is the final history stage: Colmi rings support neither blood pressure
+                // nor blood sugar (see ColmiCoordinator.capabilities and this class's stage-order doc).
+                // Finishing here — instead of querying blood sugar (0x47) — avoids an unsupported
+                // request the ring answers by re-emitting its temperature frame, which re-entered this
+                // branch and looped into a GATT write storm that starved the sleep sync. The stage
+                // guard also makes a repeated temperature frame idempotent (finish once, then ignore).
+                if (stage == Stage.TEMPERATURE) finishSync()
             }
-            ColmiCommandID.BIG_DATA_BLOOD_SUGAR -> finishSync()
         }
     }
 
@@ -302,12 +307,9 @@ class ColmiSyncEngine(
         writer?.enqueue(encoder.syncHRV(daysAgo))
     }
 
-    private fun requestBp() { writer?.enqueue(encoder.syncBp()) }
-
     private fun requestSpo2() { writer?.enqueue(encoder.bigDataSpo2()) }
     private fun requestSleep() { writer?.enqueue(encoder.bigDataSleep()) }
     private fun requestTemperature() { writer?.enqueue(encoder.bigDataTemperature()) }
-    private fun requestBloodSugar() { writer?.enqueue(encoder.bigDataBloodSugar()) }
 
     private fun dayStart(daysAgo: Int): LocalDate = LocalDate.now(zone).minusDays(daysAgo.toLong())
 
@@ -330,12 +332,9 @@ class ColmiSyncEngine(
             }
             Stage.STRESS -> { stage = Stage.SPO2; requestSpo2() }
             Stage.HRV -> {
+                // Skip BP: Colmi rings don't support it (see ColmiCoordinator.capabilities).
                 if (daysAgo < 6) { daysAgo++; requestHRV() }
-                else { stage = Stage.BP; requestBp() }
-            }
-            Stage.BP -> {
-                // BP is a single bulk response, not paged
-                stage = Stage.TEMPERATURE; requestTemperature()
+                else { stage = Stage.TEMPERATURE; requestTemperature() }
             }
             else -> {}
         }
@@ -370,10 +369,8 @@ class ColmiSyncEngine(
             Stage.STRESS -> { stage = Stage.SPO2; requestSpo2() }
             Stage.SPO2 -> { stage = Stage.SLEEP; requestSleep() }
             Stage.SLEEP -> { daysAgo = 0; stage = Stage.HRV; requestHRV() }
-            Stage.HRV -> { stage = Stage.BP; requestBp() }
-            Stage.BP -> { stage = Stage.TEMPERATURE; requestTemperature() }
-            Stage.TEMPERATURE -> { stage = Stage.BLOOD_SUGAR; requestBloodSugar() }
-            Stage.BLOOD_SUGAR -> finishSync()
+            Stage.HRV -> { stage = Stage.TEMPERATURE; requestTemperature() }  // BP unsupported — skip
+            Stage.TEMPERATURE -> finishSync()  // blood sugar unsupported — temperature is terminal
             else -> {}
         }
         if (stage != Stage.DONE) armWatchdog()

--- a/app/src/main/java/com/pulseloop/ring/ColmiSyncEngine.kt
+++ b/app/src/main/java/com/pulseloop/ring/ColmiSyncEngine.kt
@@ -43,7 +43,7 @@ class ColmiSyncEngine(
     private var userProfile: UserProfileValues? = null
 
     // History state machine
-    private enum class Stage { IDLE, ACTIVITY, HEART_RATE, STRESS, SPO2, SLEEP, HRV, BP, TEMPERATURE, BLOOD_SUGAR, DONE }
+    private enum class Stage { IDLE, ACTIVITY, HEART_RATE, STRESS, SPO2, SLEEP, HRV, TEMPERATURE, DONE }
 
     private var stage = Stage.IDLE
     private var daysAgo = 0
@@ -72,8 +72,7 @@ class ColmiSyncEngine(
             op == ColmiCommandID.SYNC_ACTIVITY ||
             op == ColmiCommandID.SYNC_HEART_RATE ||
             op == ColmiCommandID.SYNC_STRESS ||
-            op == ColmiCommandID.SYNC_HRV ||
-            op == ColmiCommandID.BP_READ
+            op == ColmiCommandID.SYNC_HRV
     }
 
     override fun runStartup() {
@@ -246,6 +245,10 @@ class ColmiSyncEngine(
     fun handleBigDataComplete(type: UByte) {
         when (type) {
             ColmiCommandID.BIG_DATA_SPO2 -> {
+                // Same stray-frame guard as SLEEP/TEMPERATURE below: rings can re-emit a big-data
+                // frame outside its stage, and an unguarded advance would jump the pipeline back
+                // to SLEEP and re-request it.
+                if (stage != Stage.SPO2) return
                 stage = Stage.SLEEP; requestSleep(); armWatchdog()
             }
             ColmiCommandID.BIG_DATA_SLEEP -> {

--- a/app/src/main/java/com/pulseloop/ring/ColmiSyncEngine.kt
+++ b/app/src/main/java/com/pulseloop/ring/ColmiSyncEngine.kt
@@ -3,6 +3,7 @@ package com.pulseloop.ring
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
+import java.time.ZoneOffset
 import java.time.temporal.ChronoUnit
 import kotlinx.coroutines.*
 
@@ -10,8 +11,9 @@ import kotlinx.coroutines.*
  * Ported from [ColmiSyncEngine] in ColmiSyncEngine.swift.
  * Colmi R02 sync engine: response-driven history state machine + realtime-HR keepalive.
  *
- * Stage order: activity(0..7) → HR(0..7) → stress → spo2(bigdata) → sleep(bigdata)
- * → hrv(0..6) → temperature(bigdata) → done.
+ * Stage order: activity(0..7) → HR(0..7) → stress(0..6) → spo2(bigdata) → sleep(bigdata)
+ * → hrv(0..6) → temperature(bigdata; interval action 119 when the ring supports it, paged
+ * per day 0..6 with per-packet continuation, else legacy action 37) → done.
  */
 class ColmiSyncEngine(
     private var writer: RingCommandWriter?,
@@ -49,6 +51,16 @@ class ColmiSyncEngine(
     private var daysAgo = 0
     private var syncDay = LocalDate.now(zone)
 
+    // Per-day paged-stage metadata from the ring's packet 0 (QRing ReadHeartRateRsp /
+    // PressureRsp / HRVRsp): how many packets the day has (drives terminal detection) and the
+    // sampling cadence in minutes (drives the decoder's timestamp grid). Reset on every request.
+    private var expectedPackets: Int? = null
+    private var slotMinutes: Int? = null
+
+    /** From the 0x3C device-support reply: ring uses the interval-temperature big-data path
+     *  (action 119) instead of the legacy action 37 that such firmware may not answer. */
+    private var supportsIntervalTemp = false
+
     /** A standalone sleep-only request is outstanding (see [syncSleepNow]). Set true when we fire
      *  `bigDataSleep()` outside the staged history sync; its big-data completion clears it and
      *  must NOT advance the pipeline into HRV. Volatile: set on Main, read on the notify thread. */
@@ -63,9 +75,13 @@ class ColmiSyncEngine(
 
     // Realtime HR keepalive
     private var realtimeHRActive = false
-    private var realtimeHRPacketCount = 0
+    private var realtimeKeepaliveJob: Job? = null
     private var manualHRActive = false
     private var manualSpO2Active = false
+
+    /** Last bpm seen while a manual spot measurement runs: QRing reports it in the 0x6A stop
+     *  frame so the ring's own measurement log records the reading (0 = cancelled). */
+    private var lastManualBpm = 0
 
     companion object {
         fun isHistoryOpcode(op: UByte): Boolean =
@@ -73,6 +89,9 @@ class ColmiSyncEngine(
             op == ColmiCommandID.SYNC_HEART_RATE ||
             op == ColmiCommandID.SYNC_STRESS ||
             op == ColmiCommandID.SYNC_HRV
+
+        /** 20 s wall-clock re-arm, matching QRing's HeartActivity timer. */
+        private const val REALTIME_KEEPALIVE_MS = 20_000L
     }
 
     override fun runStartup() {
@@ -151,10 +170,12 @@ class ColmiSyncEngine(
      * the ring's reported interval.
      */
     override fun handleRawNotify(data: ByteArray) {
-        // Device-support reply is independent of config seeding: if the ring wants a bond, ask
-        // the client to create one. Return early — a 0x3C frame carries nothing else we consume.
-        decoder.decodeDeviceSupport(data)?.let { supportsBlePair ->
-            if (supportsBlePair) onBondRequested?.invoke()
+        // Device-support reply is independent of config seeding: remember the temperature-path
+        // capability and, if the ring wants a bond, ask the client to create one. Return early —
+        // a 0x3C frame carries nothing else we consume.
+        decoder.decodeDeviceSupport(data)?.let { support ->
+            supportsIntervalTemp = support.supportsIntervalTemp
+            if (support.supportsBlePair) onBondRequested?.invoke()
             return
         }
         if (!seedingFromRing) return
@@ -231,18 +252,59 @@ class ColmiSyncEngine(
         armWatchdog()
     }
 
-    override fun handle(event: RingDecodedEvent) {}
+    override fun handle(event: RingDecodedEvent) {
+        if (manualHRActive && event is RingDecodedEvent.HeartRateSample) lastManualBpm = event.bpm
+    }
 
     // MARK: Driver hooks
 
     fun handleHistoryFrame(data: ByteArray): List<RingDecodedEvent> {
-        val events = decoder.decodeHistory(data, day = syncDay)
+        captureStageMetadata(data)
+        val events = decoder.decodeHistory(data, day = syncDay, slotMinutes = slotMinutes)
         advanceAfterPagedFrame(data)
         armWatchdog()
         return events
     }
 
-    fun handleBigDataComplete(type: UByte) {
+    /**
+     * Capture what the ring's own frames tell us about the current paged day, before decoding:
+     * - packet 0 carries the day's packet count (v[2], drives terminal detection) and the
+     *   sampling cadence in minutes (v[3]) — QRing's ReadHeartRateRsp/PressureRsp/HRVRsp;
+     * - packet 1 echoes which day the log actually belongs to (HR: start time as
+     *   "local-wall-clock read as UTC" at v[2..5]; stress/HRV: day offset at v[2]) — trust the
+     *   echo over the request-side [syncDay] so a late or shifted reply can't be attributed to
+     *   the wrong day.
+     */
+    private fun captureStageMetadata(data: ByteArray) {
+        val packet = ColmiPacket.validating(data) ?: return
+        val v = packet.bytes.map { it.toUByte() }
+        when (v[0]) {
+            ColmiCommandID.SYNC_HEART_RATE, ColmiCommandID.SYNC_STRESS, ColmiCommandID.SYNC_HRV -> {}
+            else -> return
+        }
+        when (v[1].toInt()) {
+            0 -> {
+                expectedPackets = v[2].toInt().takeIf { it in 2..64 }
+                slotMinutes = v[3].toInt().takeIf { it in 1..240 }
+            }
+            1 -> when (v[0]) {
+                ColmiCommandID.SYNC_HEART_RATE -> {
+                    val echo = v[2].toLong() or (v[3].toLong() shl 8) or
+                        (v[4].toLong() shl 16) or (v[5].toLong() shl 24)
+                    if (echo > 0) {
+                        syncDay = Instant.ofEpochSecond(echo).atZone(ZoneOffset.UTC).toLocalDate()
+                    }
+                }
+                else -> {
+                    val offset = v[2].toInt()
+                    if (offset in 0..29) syncDay = dayStart(offset)
+                }
+            }
+            else -> {}
+        }
+    }
+
+    fun handleBigDataComplete(type: UByte, data: ByteArray? = null) {
         when (type) {
             ColmiCommandID.BIG_DATA_SPO2 -> {
                 // Same stray-frame guard as SLEEP/TEMPERATURE below: rings can re-emit a big-data
@@ -276,43 +338,81 @@ class ColmiSyncEngine(
                 // guard also makes a repeated temperature frame idempotent (finish once, then ignore).
                 if (stage == Stage.TEMPERATURE) finishSync()
             }
-        }
-    }
-
-    fun observedRealtimeHeartRate() {
-        if (!realtimeHRActive) return
-        realtimeHRPacketCount = (realtimeHRPacketCount + 1) % 30
-        if (realtimeHRPacketCount == 0) {
-            writer?.enqueue(encoder.realtimeHeartRateContinue())
+            ColmiCommandID.BIG_DATA_INTERVAL_TEMPERATURE -> {
+                if (stage != Stage.TEMPERATURE) return
+                // Interval temperature (action 119) needs app-driven continuation (QRing
+                // LargeDataHandler §119): the header carries packetCount [8] / packetIndex [9];
+                // re-request packetIndex+1 until the day's last packet, then move to the next
+                // day (0..6) and finish after the oldest.
+                val packetCount = data?.getOrNull(8)?.toInt()?.and(0xFF) ?: 0
+                val packetIndex = data?.getOrNull(9)?.toInt()?.and(0xFF) ?: 0
+                when {
+                    packetCount > 0 && packetIndex < packetCount - 1 -> {
+                        writer?.enqueue(encoder.bigDataIntervalTemperature(daysAgo, packetIndex + 1))
+                        armWatchdog()
+                    }
+                    daysAgo < 6 -> {
+                        daysAgo++
+                        writer?.enqueue(encoder.bigDataIntervalTemperature(daysAgo, 0))
+                        armWatchdog()
+                    }
+                    else -> finishSync()
+                }
+            }
+            // BIG_DATA_SLEEP_LUNCH (0x3E) arrives unsolicited alongside the action-39 sleep
+            // reply on rings with nap support; the decoder already emitted its events and it
+            // must never advance the pipeline — no branch, intentionally.
         }
     }
 
     // MARK: Stage requests
 
+    private fun resetStageMetadata() {
+        expectedPackets = null
+        slotMinutes = null
+    }
+
     private fun requestActivity() {
         syncDay = dayStart(daysAgo)
+        resetStageMetadata()
         writer?.enqueue(encoder.syncActivity(daysAgo))
     }
 
     private fun requestHeartRate() {
         syncDay = dayStart(daysAgo)
-        val unix = syncDay.atStartOfDay(zone).toEpochSecond().toInt()
+        resetStageMetadata()
+        // The ring indexes its daily HR logs on "local wall clock read as UTC": QRing sends
+        // localMidnightEpoch + tzOffset (= the calendar date at 00:00 UTC) and subtracts the
+        // offset back from the echo. Sending the true local-midnight epoch landed inside the
+        // ring's previous day in GMT+ timezones.
+        val unix = syncDay.atStartOfDay(ZoneOffset.UTC).toEpochSecond().toInt()
         writer?.enqueue(encoder.syncHeartRate(unix))
     }
 
     private fun requestStress() {
-        syncDay = LocalDate.now(zone)
-        writer?.enqueue(encoder.syncStress())
+        syncDay = dayStart(daysAgo)
+        resetStageMetadata()
+        writer?.enqueue(encoder.syncStress(daysAgo))
     }
 
     private fun requestHRV() {
         syncDay = dayStart(daysAgo)
+        resetStageMetadata()
         writer?.enqueue(encoder.syncHRV(daysAgo))
     }
 
     private fun requestSpo2() { writer?.enqueue(encoder.bigDataSpo2()) }
     private fun requestSleep() { writer?.enqueue(encoder.bigDataSleep()) }
-    private fun requestTemperature() { writer?.enqueue(encoder.bigDataTemperature()) }
+
+    private fun requestTemperature() {
+        if (supportsIntervalTemp) {
+            // Modern path (QRing gates on the same 0x3C bit): per-day interval series, starting
+            // at today packet 0; handleBigDataComplete drives packet/day continuation.
+            writer?.enqueue(encoder.bigDataIntervalTemperature(daysAgo, 0))
+        } else {
+            writer?.enqueue(encoder.bigDataTemperature())
+        }
+    }
 
     private fun dayStart(daysAgo: Int): LocalDate = LocalDate.now(zone).minusDays(daysAgo.toLong())
 
@@ -331,24 +431,44 @@ class ColmiSyncEngine(
             }
             Stage.HEART_RATE -> {
                 if (daysAgo < 7) { daysAgo++; requestHeartRate() }
-                else { stage = Stage.STRESS; requestStress() }
+                else { daysAgo = 0; stage = Stage.STRESS; requestStress() }
             }
-            Stage.STRESS -> { stage = Stage.SPO2; requestSpo2() }
+            Stage.STRESS -> {
+                // Stress pages over today+6 like HRV (QRing PressureRepository); the old
+                // single bare-0x37 request only ever fetched today.
+                if (daysAgo < 6) { daysAgo++; requestStress() }
+                else { stage = Stage.SPO2; requestSpo2() }
+            }
             Stage.HRV -> {
                 // Skip BP: Colmi rings don't support it (see ColmiCoordinator.capabilities).
                 if (daysAgo < 6) { daysAgo++; requestHRV() }
-                else { stage = Stage.TEMPERATURE; requestTemperature() }
+                else { daysAgo = 0; stage = Stage.TEMPERATURE; requestTemperature() }
             }
             else -> {}
         }
     }
 
+    /**
+     * A day's last data packet. QRing ends a day at packet == size−1, where size comes from the
+     * day's packet 0 ([captureStageMetadata]) — the old hardcoded checks (nothing for HR, 4 for
+     * stress/HRV) meant an HR day with data NEVER completed: the watchdog force-skipped the
+     * whole stage and days 1..7 were never requested. Fallbacks when packet 0 was missed:
+     * stress/HRV keep the old size-5 assumption; HR ends on packet 23 (24 packets ≥ a full
+     * 5-min-cadence day — QRing's today-cap) or the watchdog.
+     */
     private fun isTerminalPacket(data: ByteArray): Boolean {
         val v = data.map { it.toUByte() }
         if (v.size < 7) return false
+        val packetNr = v[1].toInt()
         return when (v[0]) {
-            ColmiCommandID.SYNC_STRESS, ColmiCommandID.SYNC_HRV -> v[1].toInt() == 4
-            ColmiCommandID.SYNC_ACTIVITY -> v[5].toInt() == v[6].toInt() - 1
+            ColmiCommandID.SYNC_STRESS, ColmiCommandID.SYNC_HRV ->
+                packetNr >= 2 && packetNr == (expectedPackets ?: 5) - 1
+            ColmiCommandID.SYNC_HEART_RATE ->
+                (packetNr >= 2 && packetNr == (expectedPackets ?: -1) - 1) || packetNr == 23
+            // Gate the steps/day-count equality off the 0xF0 header packet — QRing evaluates it
+            // only for data packets, and a header satisfying it would end the day early.
+            ColmiCommandID.SYNC_ACTIVITY ->
+                packetNr != 0xF0 && v[5].toInt() == v[6].toInt() - 1
             else -> false
         }
     }
@@ -368,11 +488,11 @@ class ColmiSyncEngine(
     private fun forceAdvanceStage(stuck: Stage) {
         when (stuck) {
             Stage.ACTIVITY -> { daysAgo = 0; stage = Stage.HEART_RATE; requestHeartRate() }
-            Stage.HEART_RATE -> { stage = Stage.STRESS; requestStress() }
+            Stage.HEART_RATE -> { daysAgo = 0; stage = Stage.STRESS; requestStress() }
             Stage.STRESS -> { stage = Stage.SPO2; requestSpo2() }
             Stage.SPO2 -> { stage = Stage.SLEEP; requestSleep() }
             Stage.SLEEP -> { daysAgo = 0; stage = Stage.HRV; requestHRV() }
-            Stage.HRV -> { stage = Stage.TEMPERATURE; requestTemperature() }  // BP unsupported — skip
+            Stage.HRV -> { daysAgo = 0; stage = Stage.TEMPERATURE; requestTemperature() }  // BP unsupported — skip
             Stage.TEMPERATURE -> finishSync()  // blood sugar unsupported — temperature is terminal
             else -> {}
         }
@@ -389,14 +509,24 @@ class ColmiSyncEngine(
 
     override fun startHeartRate() {
         realtimeHRActive = true
-        realtimeHRPacketCount = 0
         writer?.enqueue(encoder.realtimeHeartRate(enable = true))
+        // Re-arm the stream on a wall-clock timer like QRing (20 s), not per received frame:
+        // a frame-count keepalive starves exactly when the ring pauses the stream to wait for
+        // the continue, killing the session.
+        realtimeKeepaliveJob?.cancel()
+        realtimeKeepaliveJob = scope.launch {
+            while (isActive) {
+                delay(REALTIME_KEEPALIVE_MS)
+                if (realtimeHRActive) writer?.enqueue(encoder.realtimeHeartRateContinue())
+            }
+        }
     }
 
     override fun stopHeartRate() {
+        realtimeKeepaliveJob?.cancel(); realtimeKeepaliveJob = null
         if (manualHRActive) {
             manualHRActive = false
-            writer?.enqueue(encoder.manualHeartRate(enable = false))
+            writer?.enqueue(encoder.manualHeartRate(enable = false, lastBpm = lastManualBpm))
         }
         if (!realtimeHRActive) return
         realtimeHRActive = false
@@ -405,6 +535,7 @@ class ColmiSyncEngine(
 
     override fun measureHeartRateSpot() {
         manualHRActive = true
+        lastManualBpm = 0
         writer?.enqueue(encoder.manualHeartRate(enable = true))
     }
 

--- a/app/src/main/java/com/pulseloop/ui/PulseLoopApp.kt
+++ b/app/src/main/java/com/pulseloop/ui/PulseLoopApp.kt
@@ -7,6 +7,7 @@ import androidx.compose.material.icons.filled.*
 import androidx.compose.material.icons.outlined.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
 import kotlinx.coroutines.launch
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -216,7 +217,10 @@ fun PulseLoopApp() {
         // versionCode keeps the frequent checks from re-nagging about the same release within
         // a session. Settings also has a manual "Check for updates".
         var pendingUpdate by remember { mutableStateOf<com.pulseloop.update.UpdateInfo?>(null) }
-        var dismissedUpdateCode by remember { mutableStateOf<Int?>(null) }
+        // rememberSaveable so a dismissed release stays dismissed across config changes
+        // (rotation) — plain remember would reset and let the throttle-expired foreground
+        // check re-nag about the same version.
+        var dismissedUpdateCode by rememberSaveable { mutableStateOf<Int?>(null) }
         val updateScope = rememberCoroutineScope()
         val updateLifecycleOwner = LocalLifecycleOwner.current
         DisposableEffect(updateLifecycleOwner) {

--- a/app/src/main/java/com/pulseloop/ui/PulseLoopApp.kt
+++ b/app/src/main/java/com/pulseloop/ui/PulseLoopApp.kt
@@ -7,6 +7,7 @@ import androidx.compose.material.icons.filled.*
 import androidx.compose.material.icons.outlined.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import kotlinx.coroutines.launch
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -208,12 +209,30 @@ fun PulseLoopApp() {
             Tab("coach", "Coach", Icons.Filled.AutoAwesome, Icons.Outlined.AutoAwesome),
         )
 
-        // ── Self-update: release-only, throttled to once/day. Surfaces a dialog when a
-        // newer GitHub release is published; Settings also has a manual "Check for updates".
+        // ── Self-update: release-only. Checked on every return to foreground (ON_START also
+        // fires on cold start — lifecycle observers replay up to the current state), so a
+        // long-running app notices a new release without a force-close. UpdateChecker's
+        // 15-min throttle + ETag caching bound the GitHub traffic; remembering the dismissed
+        // versionCode keeps the frequent checks from re-nagging about the same release within
+        // a session. Settings also has a manual "Check for updates".
         var pendingUpdate by remember { mutableStateOf<com.pulseloop.update.UpdateInfo?>(null) }
-        LaunchedEffect(Unit) {
-            pendingUpdate = (com.pulseloop.update.UpdateChecker.check(context)
-                as? com.pulseloop.update.UpdateCheckResult.UpdateAvailable)?.info
+        var dismissedUpdateCode by remember { mutableStateOf<Int?>(null) }
+        val updateScope = rememberCoroutineScope()
+        val updateLifecycleOwner = LocalLifecycleOwner.current
+        DisposableEffect(updateLifecycleOwner) {
+            val observer = LifecycleEventObserver { _, event ->
+                if (event == Lifecycle.Event.ON_START) {
+                    updateScope.launch {
+                        val info = (com.pulseloop.update.UpdateChecker.check(context)
+                            as? com.pulseloop.update.UpdateCheckResult.UpdateAvailable)?.info
+                        if (info != null && info.versionCode != dismissedUpdateCode) {
+                            pendingUpdate = info
+                        }
+                    }
+                }
+            }
+            updateLifecycleOwner.lifecycle.addObserver(observer)
+            onDispose { updateLifecycleOwner.lifecycle.removeObserver(observer) }
         }
 
         val isLandscape =
@@ -515,7 +534,12 @@ fun PulseLoopApp() {
         }
 
         pendingUpdate?.let { info ->
-            com.pulseloop.update.UpdateDialog(info) { pendingUpdate = null }
+            com.pulseloop.update.UpdateDialog(info) {
+                // Remember what was dismissed: foreground checks now run every ON_START, and
+                // without this the same release would re-prompt on every app switch.
+                dismissedUpdateCode = info.versionCode
+                pendingUpdate = null
+            }
         }
     }
 }

--- a/app/src/main/java/com/pulseloop/update/UpdateChecker.kt
+++ b/app/src/main/java/com/pulseloop/update/UpdateChecker.kt
@@ -70,7 +70,16 @@ object UpdateChecker {
     private const val KEY_ETAG = "etag"
     private const val KEY_CACHED_RELEASE = "cachedReleaseJson"
     private const val KEY_LAST_CHECK = "lastCheckAt"
-    private const val AUTO_CHECK_INTERVAL_MS = 24 * 3600_000L
+
+    /**
+     * Minimum gap between automatic checks. Auto-checks fire on every background→foreground
+     * transition (plus cold start), so this is what actually bounds GitHub traffic: at most
+     * 4 requests/hour, and repeat checks send If-None-Match, whose 304 replies don't count
+     * against GitHub's rate limit at all. 15 min keeps a long-running app noticing a new
+     * release quickly without the old force-close-and-relaunch (previously this was 24 h,
+     * which made foreground checks pointless).
+     */
+    private const val AUTO_CHECK_INTERVAL_MS = 15 * 60_000L
 
     fun isSupported(): Boolean =
         !BuildConfig.DEBUG && BuildConfig.APPLICATION_ID == "com.pulseloop"
@@ -80,12 +89,13 @@ object UpdateChecker {
 
     /**
      * Checks the GitHub latest release against the installed build. [force] bypasses the
-     * once-a-day throttle and the ETag cache (used by the Settings "Check for updates" button).
+     * auto-check throttle and the ETag cache (used by the Settings "Check for updates" button).
      *
      * A 304 Not Modified still re-evaluates the release cached alongside the ETag — the
      * throttle is the only thing that limits how often the result surfaces. Otherwise a
      * pending update the user dismissed once would never be offered again while that
-     * release's ETag stays current.
+     * release's ETag stays current. (Nag control for the frequent foreground checks lives
+     * at the call site, which remembers the dismissed versionCode for the session.)
      */
     suspend fun check(context: Context, force: Boolean = false): UpdateCheckResult = withContext(Dispatchers.IO) {
         if (!isSupported()) return@withContext UpdateCheckResult.Skipped

--- a/app/src/test/java/com/pulseloop/ring/ColmiDecoderTest.kt
+++ b/app/src/test/java/com/pulseloop/ring/ColmiDecoderTest.kt
@@ -411,17 +411,35 @@ class ColmiDecoderTest {
         assertArrayEquals(byteArrayOf(0x16, 0x02, 0x02, 0x05, 0x00, 0x00, 0x00, 0x00), cmd)
     }
 
-    // Device-support (0x3C): supportBlePair is bit 3 (0x08) of the first feature byte (frame[1]).
+    // Device-support (0x3C): QRing's QCDataParser strips the opcode before the rsp class runs,
+    // so supportBlePair (rsp bArr[1] & 0x08) is FULL-frame byte 2, and supportIntervalTemp
+    // (rsp bArr[8] & 0x80) is full-frame byte 9. The original port read frame[1] — a byte QRing
+    // never parses — which silently broke the R09 bond gate.
     @Test
-    fun `device support decodes supportBlePair bit`() {
-        // frame[1] = 0x08 → bond wanted
-        assertEquals(true, ColmiDecoder.decodeDeviceSupport(ColmiPacket.frame(byteArrayOf(0x3C, 0x08))))
-        // frame[1] = 0x0F (bit set among others) → still true
-        assertEquals(true, ColmiDecoder.decodeDeviceSupport(ColmiPacket.frame(byteArrayOf(0x3C, 0x0F))))
-        // frame[1] = 0x07 (bit clear) → false
-        assertEquals(false, ColmiDecoder.decodeDeviceSupport(ColmiPacket.frame(byteArrayOf(0x3C, 0x07))))
+    fun `device support decodes supportBlePair from full-frame byte 2`() {
+        assertEquals(true, ColmiDecoder.decodeDeviceSupport(
+            ColmiPacket.frame(byteArrayOf(0x3C, 0x00, 0x08)))?.supportsBlePair)
+        // Bit set among others → still true
+        assertEquals(true, ColmiDecoder.decodeDeviceSupport(
+            ColmiPacket.frame(byteArrayOf(0x3C, 0x00, 0x0F)))?.supportsBlePair)
+        // Bit clear → false
+        assertEquals(false, ColmiDecoder.decodeDeviceSupport(
+            ColmiPacket.frame(byteArrayOf(0x3C, 0x00, 0x07)))?.supportsBlePair)
+        // The OLD (wrong) offset must not trigger a bond: bit in frame[1], frame[2] clear.
+        assertEquals(false, ColmiDecoder.decodeDeviceSupport(
+            ColmiPacket.frame(byteArrayOf(0x3C, 0x08, 0x00)))?.supportsBlePair)
         // Not a device-support frame → null
         assertNull(ColmiDecoder.decodeDeviceSupport(ColmiPacket.frame(byteArrayOf(0x16, 0x01, 0x01, 30))))
+    }
+
+    @Test
+    fun `device support decodes supportIntervalTemp from full-frame byte 9`() {
+        val withBit = ColmiPacket.frame(
+            byteArrayOf(0x3C, 0, 0, 0, 0, 0, 0, 0, 0, 0x80.toByte()))
+        assertEquals(true, ColmiDecoder.decodeDeviceSupport(withBit)?.supportsIntervalTemp)
+        val withoutBit = ColmiPacket.frame(
+            byteArrayOf(0x3C, 0, 0, 0, 0, 0, 0, 0, 0, 0x7F))
+        assertEquals(false, ColmiDecoder.decodeDeviceSupport(withoutBit)?.supportsIntervalTemp)
     }
 
     @Test

--- a/app/src/test/java/com/pulseloop/ring/ColmiDecoderTest.kt
+++ b/app/src/test/java/com/pulseloop/ring/ColmiDecoderTest.kt
@@ -203,16 +203,23 @@ class ColmiDecoderTest {
     }
 
     @Test
-    fun `interleaved big data does not corrupt`() {
+    fun `sequential big data transfers each decode and reset the buffer`() {
+        // Real rings stream one big-data reply at a time (QRing can't handle interleaving, so
+        // firmware doesn't produce it). Verify the reassembly buffer resets cleanly between
+        // transfers: a split SpO2 transfer completes, then a whole sleep frame decodes without
+        // being contaminated by the previous transfer.
         val driver = ColmiDriver(NullWriter())
         val notifyV2 = ColmiUUIDs.NOTIFY_V2
 
-        // SpO2 frame: one day, min=96,max=98 at hour 0
         var spo2Payload = byteArrayOf(0x00, 96, 98)
         spo2Payload += ByteArray(46)
         val spo2Full = bigData(ColmiCommandID.BIG_DATA_SPO2, spo2Payload)
+        driver.ingest(spo2Full.copyOfRange(0, 12), notifyV2)
+        val spo2Events = driver.ingest(spo2Full.copyOfRange(12, spo2Full.size), notifyV2)
+        val spo2Values = spo2Events.filterIsInstance<RingDecodedEvent.HistoryMeasurement>()
+            .filter { it.kind_field == MeasurementKind.SPO2 }
+        assertEquals(97.0, spo2Values.first().value, 0.01)
 
-        // Sleep frame: complete in one notification
         val start = 480; val end = 540
         val sleepPayload = byteArrayOf(
             0x01, 0x00, 0x08,
@@ -221,25 +228,9 @@ class ColmiDecoderTest {
             ColmiCommandID.SLEEP_DEEP.toByte(), 30,
             ColmiCommandID.SLEEP_REM.toByte(), 30,
         )
-        val len = sleepPayload.size
-        val sleepFull = byteArrayOf(
-            0xBC.toByte(), ColmiCommandID.BIG_DATA_SLEEP.toByte(),
-            (len and 0xFF).toByte(), ((len shr 8) and 0xFF).toByte(),
-            0, 0
-        ) + sleepPayload
-
-        // Interleave: SpO2 header → complete sleep → SpO2 continuation
-        val spo2First = spo2Full.copyOfRange(0, 12)
-        val spo2Rest = spo2Full.copyOfRange(12, spo2Full.size)
-
-        driver.ingest(spo2First, notifyV2)
+        val sleepFull = bigData(ColmiCommandID.BIG_DATA_SLEEP, sleepPayload)
         val sleepEvents = driver.ingest(sleepFull, notifyV2)
-        val spo2Events = driver.ingest(spo2Rest, notifyV2)
-
         assertTrue(sleepEvents.any { it is RingDecodedEvent.SleepTimeline })
-        val spo2Values = spo2Events.filterIsInstance<RingDecodedEvent.HistoryMeasurement>()
-            .filter { it.kind_field == MeasurementKind.SPO2 }
-        assertEquals(97.0, spo2Values.first().value, 0.01)
     }
 
     // MARK: Real R11 captures

--- a/app/src/test/java/com/pulseloop/ring/ColmiMeasurementSettingsTest.kt
+++ b/app/src/test/java/com/pulseloop/ring/ColmiMeasurementSettingsTest.kt
@@ -20,8 +20,16 @@ class ColmiMeasurementSettingsTest {
 
     @Test
     fun `temp pref write mirrors the extra 0x03 framing byte`() {
-        assertArrayEquals(byteArrayOf(0x3A, 0x03, 0x02, 0x01), ColmiEncoder.writeTempPref(enabled = true))
-        assertArrayEquals(byteArrayOf(0x3A, 0x03, 0x02, 0x00), ColmiEncoder.writeTempPref(enabled = false))
+        // Full 6-field record (QRing SugarLipidsSettingReq.getWriteInstance((byte)3, …)):
+        // enable, interval 30, start 5, remind-interval 10, alert bits 0, custom byte 0xB9
+        // (38.5 °C, inert with bits=0). The old 4-byte truncated form read as interval=0 on
+        // RT-series firmware — ACKed but never armed background sampling.
+        assertArrayEquals(
+            byteArrayOf(0x3A, 0x03, 0x02, 0x01, 30, 5, 10, 0x00, 0xB9.toByte()),
+            ColmiEncoder.writeTempPref(enabled = true))
+        assertArrayEquals(
+            byteArrayOf(0x3A, 0x03, 0x02, 0x00, 30, 5, 10, 0x00, 0xB9.toByte()),
+            ColmiEncoder.writeTempPref(enabled = false))
     }
 
     // MARK: UserProfileValues mapping
@@ -63,7 +71,7 @@ class ColmiMeasurementSettingsTest {
         assertEquals(15.toByte(), autoHr[3])         // configured interval
         val stress = writer.commands.first { it[0] == 0x36.toByte() && it[1] == 0x02.toByte() }
         assertEquals(0x00.toByte(), stress[2])       // stress off
-        val temp = writer.commands.first { it[0] == 0x3A.toByte() && it.size == 4 && it[2] == 0x02.toByte() }
+        val temp = writer.commands.first { it[0] == 0x3A.toByte() && it.size == 9 && it[2] == 0x02.toByte() }
         assertEquals(0x00.toByte(), temp[3])         // temperature off
     }
 
@@ -212,12 +220,13 @@ class ColmiMeasurementSettingsTest {
         var bondRequests = 0
         engine.setOnBondRequested { bondRequests++ }
 
-        // Feature byte with bit 3 set → bond wanted.
-        engine.handleRawNotify(ColmiPacket.frame(byteArrayOf(0x3C, 0x08)))
+        // Feature byte (full-frame [2] — QRing rsp classes see the opcode-stripped slice, so
+        // their bArr[1] is full-frame byte 2) with bit 3 set → bond wanted.
+        engine.handleRawNotify(ColmiPacket.frame(byteArrayOf(0x3C, 0x00, 0x08)))
         assertEquals(1, bondRequests)
 
         // Feature byte without bit 3 → no bond.
-        engine.handleRawNotify(ColmiPacket.frame(byteArrayOf(0x3C, 0x07)))
+        engine.handleRawNotify(ColmiPacket.frame(byteArrayOf(0x3C, 0x00, 0x07)))
         assertEquals(1, bondRequests)
         engine.destroy()
     }

--- a/app/src/test/java/com/pulseloop/ring/ColmiQringParityTest.kt
+++ b/app/src/test/java/com/pulseloop/ring/ColmiQringParityTest.kt
@@ -128,6 +128,27 @@ class ColmiQringParityTest {
         engine.destroy()
     }
 
+    @Test
+    fun `a garbage HR echo does not future-date samples`() {
+        val writer = RecordingWriter()
+        val engine = ColmiSyncEngine(writer, ColmiDecoder)
+        engine.runStartup()
+        repeat(8) { engine.handleHistoryFrame(emptyDayFrame(ColmiCommandID.SYNC_ACTIVITY)) }
+        // Stage = HEART_RATE, day 0. Packet 0 announces the size.
+        engine.handleHistoryFrame(ColmiPacket.frame(byteArrayOf(0x15, 0x00, 0x03, 0x05)))
+        // Packet 1 with an all-0xFF time echo (≈ year 2106) and one HR sample. The echo is
+        // out of the ±2-day window, so it must be rejected and the sample stays on today.
+        val events = engine.handleHistoryFrame(ColmiPacket.frame(
+            byteArrayOf(0x15, 0x01, 0xFF.toByte(), 0xFF.toByte(), 0xFF.toByte(), 0xFF.toByte(), 70)))
+        val hr = events.filterIsInstance<RingDecodedEvent.HistoryMeasurement>()
+            .first { it.kind_field == MeasurementKind.HEART_RATE }
+        val sysZone = ZoneId.systemDefault()
+        val cutoff = LocalDate.now(sysZone).plusDays(2).atStartOfDay(sysZone).toInstant()
+        assertTrue("garbage echo must not push HR samples into the future",
+            hr._timestamp.isBefore(cutoff))
+        engine.destroy()
+    }
+
     // MARK: Stress 7-day paging
 
     @Test
@@ -151,9 +172,9 @@ class ColmiQringParityTest {
 
     // MARK: Interval temperature (action 119)
 
-    @Test
-    fun `interval-temp ring pages temperature per day with packet continuation`() {
-        val writer = RecordingWriter()
+    /** Drive an interval-temp-capable engine to the TEMPERATURE stage: the first action-119
+     *  request (day 0, packet 0) is now the last enqueued command. */
+    private fun driveToIntervalTemperature(writer: RecordingWriter): ColmiSyncEngine {
         val engine = ColmiSyncEngine(writer, ColmiDecoder)
         // 0x3C reply with supportIntervalTemp (full-frame byte 9, bit 0x80).
         engine.handleRawNotify(ColmiPacket.frame(
@@ -165,6 +186,13 @@ class ColmiQringParityTest {
         engine.handleBigDataComplete(ColmiCommandID.BIG_DATA_SPO2)
         engine.handleBigDataComplete(ColmiCommandID.BIG_DATA_SLEEP)
         repeat(7) { engine.handleHistoryFrame(emptyDayFrame(ColmiCommandID.SYNC_HRV)) }
+        return engine
+    }
+
+    @Test
+    fun `interval-temp ring pages temperature per day with packet continuation`() {
+        val writer = RecordingWriter()
+        val engine = driveToIntervalTemperature(writer)
 
         // Stage = TEMPERATURE: the request must be action 119 for (day 0, packet 0).
         var request = writer.commands.last()
@@ -202,6 +230,28 @@ class ColmiQringParityTest {
             ColmiCommandID.BIG_DATA_INTERVAL_TEMPERATURE,
             bigData(ColmiCommandID.BIG_DATA_INTERVAL_TEMPERATURE, byteArrayOf(0x06, 30, 0x01, 0x00)))
         assertEquals(countAtEnd, writer.commands.size)
+        engine.destroy()
+    }
+
+    @Test
+    fun `interval-temp continuation does not loop when firmware stalls the packet index`() {
+        val writer = RecordingWriter()
+        val engine = driveToIntervalTemperature(writer)
+        // day 0 packet 0 requested. Ring: count 3, index 0 → legitimately request (day0, packet1).
+        engine.handleBigDataComplete(
+            ColmiCommandID.BIG_DATA_INTERVAL_TEMPERATURE,
+            bigData(ColmiCommandID.BIG_DATA_INTERVAL_TEMPERATURE, byteArrayOf(0x00, 30, 0x03, 0x00)))
+        assertArrayEquals("first reply advances within day 0",
+            byteArrayOf(0x00, 0x01), writer.commands.last().copyOfRange(6, 8))
+
+        // Ring stalls: replies packetIndex 0 again instead of 1. Must NOT re-request the same
+        // (day0, packet1) — that reply would re-arm the watchdog and loop forever. Drop to the
+        // next day (day1, packet0) instead.
+        engine.handleBigDataComplete(
+            ColmiCommandID.BIG_DATA_INTERVAL_TEMPERATURE,
+            bigData(ColmiCommandID.BIG_DATA_INTERVAL_TEMPERATURE, byteArrayOf(0x00, 30, 0x03, 0x00)))
+        assertArrayEquals("a stalled index drops to the next day, not a re-request",
+            byteArrayOf(0x01, 0x00), writer.commands.last().copyOfRange(6, 8))
         engine.destroy()
     }
 

--- a/app/src/test/java/com/pulseloop/ring/ColmiQringParityTest.kt
+++ b/app/src/test/java/com/pulseloop/ring/ColmiQringParityTest.kt
@@ -1,0 +1,302 @@
+package com.pulseloop.ring
+
+import java.time.LocalDate
+import java.time.ZoneId
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Protocol-parity regression tests for the QRing-decompile audit fixes: HR/stress paging and
+ * terminal detection, the interval-temperature (action 119) path, multi-day SpO2 blocks,
+ * nap/lunch sleep (action 62), big-data reassembly hardening, and the corrected request frames.
+ * Byte layouts verified against the decompiled official app (QCDataParser strips the opcode
+ * before rsp classes run, so rsp `bArr[N]` = full-frame byte N+1).
+ */
+class ColmiQringParityTest {
+
+    private val zone: ZoneId = ZoneId.of("UTC")
+
+    private class RecordingWriter : RingCommandWriter {
+        val commands = mutableListOf<ByteArray>()
+        override fun enqueue(command: ByteArray) { commands.add(command) }
+    }
+
+    private fun emptyDayFrame(op: UByte): ByteArray = byteArrayOf(op.toByte(), 0xFF.toByte())
+
+    private fun bigData(type: UByte, payload: ByteArray): ByteArray = byteArrayOf(
+        0xBC.toByte(), type.toByte(),
+        (payload.size and 0xFF).toByte(), ((payload.size shr 8) and 0xFF).toByte(),
+        0, 0,
+    ) + payload
+
+    // MARK: Request frames
+
+    @Test
+    fun `syncStress carries the day index like QRing PressureReq`() {
+        assertArrayEquals(byteArrayOf(0x37, 0x00), ColmiEncoder.syncStress(0))
+        assertArrayEquals(byteArrayOf(0x37, 0x04), ColmiEncoder.syncStress(4))
+    }
+
+    @Test
+    fun `heart rate request sends the calendar date at midnight UTC`() {
+        // QRing sends localMidnightEpoch + tzOffset — i.e. the calendar date at 00:00 UTC —
+        // because the ring indexes daily logs on "local wall clock read as UTC". A true
+        // local-midnight epoch lands inside the ring's previous day in GMT+ timezones.
+        val writer = RecordingWriter()
+        val engine = ColmiSyncEngine(writer, ColmiDecoder)
+        engine.runStartup()
+        repeat(8) { engine.handleHistoryFrame(emptyDayFrame(ColmiCommandID.SYNC_ACTIVITY)) }
+
+        val hrRequest = writer.commands.last()
+        assertEquals(ColmiCommandID.SYNC_HEART_RATE.toByte(), hrRequest[0])
+        val sent = (hrRequest[1].toLong() and 0xFF) or ((hrRequest[2].toLong() and 0xFF) shl 8) or
+            ((hrRequest[3].toLong() and 0xFF) shl 16) or ((hrRequest[4].toLong() and 0xFF) shl 24)
+        val expected = LocalDate.now(ZoneId.systemDefault())
+            .atStartOfDay(java.time.ZoneOffset.UTC).toEpochSecond()
+        assertEquals(expected, sent)
+        engine.destroy()
+    }
+
+    @Test
+    fun `big data temperature request asks for six days with a valid CRC`() {
+        // addHeader(37, [6]): CRC16/MODBUS([0x06]) = 0x423F → LE 3f 42.
+        assertArrayEquals(
+            byteArrayOf(0xBC.toByte(), 0x25, 0x01, 0x00, 0x3F, 0x42, 0x06),
+            ColmiEncoder.bigDataTemperature())
+    }
+
+    @Test
+    fun `interval temperature request frames dayIndex and packetIndex`() {
+        val frame = ColmiEncoder.bigDataIntervalTemperature(daysAgo = 3, packetIndex = 2)
+        assertEquals(0xBC.toByte(), frame[0])
+        assertEquals(0x77.toByte(), frame[1])                    // action 119
+        assertArrayEquals(byteArrayOf(0x02, 0x00), frame.copyOfRange(2, 4))  // len = 2 LE
+        assertArrayEquals(byteArrayOf(0x03, 0x02), frame.copyOfRange(6, 8))  // payload
+    }
+
+    @Test
+    fun `manual spo2 start uses QRing's BCD-25 action byte`() {
+        assertArrayEquals(byteArrayOf(0x69, 0x03, 0x25), ColmiEncoder.manualSpO2(enable = true))
+    }
+
+    @Test
+    fun `manual heart rate stop reports the final reading`() {
+        assertArrayEquals(
+            byteArrayOf(0x6A, 0x01, 72, 0x00),
+            ColmiEncoder.manualHeartRate(enable = false, lastBpm = 72))
+    }
+
+    @Test
+    fun `setDateTime carries the language byte`() {
+        val frame = ColmiEncoder.setDateTime()
+        assertEquals(8, frame.size)
+        val expected: Byte = if (java.util.Locale.getDefault().language == "zh") 0x00 else 0x01
+        assertEquals(expected, frame[7])
+    }
+
+    @Test
+    fun `user preferences carry the 120-90 BP reference like QRing`() {
+        val frame = ColmiEncoder.userPreferences()
+        assertEquals(0x78.toByte(), frame[8])   // sbp 120
+        assertEquals(0x5A.toByte(), frame[9])   // dbp 90
+    }
+
+    // MARK: HR history terminal detection (packet-0 size)
+
+    @Test
+    fun `hr day with data completes at packet size-1 and advances to the next day`() {
+        val writer = RecordingWriter()
+        val engine = ColmiSyncEngine(writer, ColmiDecoder)
+        engine.runStartup()
+        repeat(8) { engine.handleHistoryFrame(emptyDayFrame(ColmiCommandID.SYNC_ACTIVITY)) }
+        // Stage = HEART_RATE, daysAgo = 0; one HR request enqueued.
+        val countAtHrDay0 = writer.commands.size
+
+        // Packet 0 announces size=3 (packets 0,1,2) at v[2] — QRing ReadHeartRateRsp.
+        engine.handleHistoryFrame(ColmiPacket.frame(byteArrayOf(0x15, 0x00, 0x03, 0x05)))
+        assertEquals("packet 0 must not advance the day", countAtHrDay0, writer.commands.size)
+        // Packet 1 (time echo + samples) is not terminal either.
+        engine.handleHistoryFrame(ColmiPacket.frame(byteArrayOf(0x15, 0x01, 0, 0, 0, 0, 70, 71)))
+        assertEquals("packet 1 must not advance the day", countAtHrDay0, writer.commands.size)
+        // Packet 2 == size-1: terminal → the engine must request the NEXT day. Pre-fix, an HR
+        // day with data never completed and the watchdog skipped the whole stage.
+        engine.handleHistoryFrame(ColmiPacket.frame(byteArrayOf(0x15, 0x02, 72, 73, 74, 0, 0)))
+        assertEquals(countAtHrDay0 + 1, writer.commands.size)
+        assertEquals(ColmiCommandID.SYNC_HEART_RATE.toByte(), writer.commands.last()[0])
+        engine.destroy()
+    }
+
+    // MARK: Stress 7-day paging
+
+    @Test
+    fun `stress pages over seven days before advancing to spo2`() {
+        val writer = RecordingWriter()
+        val engine = ColmiSyncEngine(writer, ColmiDecoder)
+        engine.runStartup()
+        repeat(8) { engine.handleHistoryFrame(emptyDayFrame(ColmiCommandID.SYNC_ACTIVITY)) }
+        repeat(8) { engine.handleHistoryFrame(emptyDayFrame(ColmiCommandID.SYNC_HEART_RATE)) }
+        // Stage = STRESS day 0. Two empty days → the third request must be [0x37, 0x02].
+        engine.handleHistoryFrame(emptyDayFrame(ColmiCommandID.SYNC_STRESS))
+        engine.handleHistoryFrame(emptyDayFrame(ColmiCommandID.SYNC_STRESS))
+        assertArrayEquals(byteArrayOf(0x37, 0x02), writer.commands.last())
+        // Five more empty days exhaust 0..6 → SpO2 big-data request.
+        repeat(5) { engine.handleHistoryFrame(emptyDayFrame(ColmiCommandID.SYNC_STRESS)) }
+        val spo2 = writer.commands.last()
+        assertEquals(0xBC.toByte(), spo2[0])
+        assertEquals(ColmiCommandID.BIG_DATA_SPO2.toByte(), spo2[1])
+        engine.destroy()
+    }
+
+    // MARK: Interval temperature (action 119)
+
+    @Test
+    fun `interval-temp ring pages temperature per day with packet continuation`() {
+        val writer = RecordingWriter()
+        val engine = ColmiSyncEngine(writer, ColmiDecoder)
+        // 0x3C reply with supportIntervalTemp (full-frame byte 9, bit 0x80).
+        engine.handleRawNotify(ColmiPacket.frame(
+            byteArrayOf(0x3C, 0, 0, 0, 0, 0, 0, 0, 0, 0x80.toByte())))
+        engine.runStartup()
+        repeat(8) { engine.handleHistoryFrame(emptyDayFrame(ColmiCommandID.SYNC_ACTIVITY)) }
+        repeat(8) { engine.handleHistoryFrame(emptyDayFrame(ColmiCommandID.SYNC_HEART_RATE)) }
+        repeat(7) { engine.handleHistoryFrame(emptyDayFrame(ColmiCommandID.SYNC_STRESS)) }
+        engine.handleBigDataComplete(ColmiCommandID.BIG_DATA_SPO2)
+        engine.handleBigDataComplete(ColmiCommandID.BIG_DATA_SLEEP)
+        repeat(7) { engine.handleHistoryFrame(emptyDayFrame(ColmiCommandID.SYNC_HRV)) }
+
+        // Stage = TEMPERATURE: the request must be action 119 for (day 0, packet 0).
+        var request = writer.commands.last()
+        assertEquals(0x77.toByte(), request[1])
+        assertArrayEquals(byteArrayOf(0x00, 0x00), request.copyOfRange(6, 8))
+
+        // Reply says day 0 has 2 packets, this was packet 0 → continuation (day 0, packet 1).
+        engine.handleBigDataComplete(
+            ColmiCommandID.BIG_DATA_INTERVAL_TEMPERATURE,
+            bigData(ColmiCommandID.BIG_DATA_INTERVAL_TEMPERATURE,
+                byteArrayOf(0x00, 30, 0x02, 0x00)))
+        request = writer.commands.last()
+        assertArrayEquals(byteArrayOf(0x00, 0x01), request.copyOfRange(6, 8))
+
+        // Last packet of day 0 → next day (day 1, packet 0).
+        engine.handleBigDataComplete(
+            ColmiCommandID.BIG_DATA_INTERVAL_TEMPERATURE,
+            bigData(ColmiCommandID.BIG_DATA_INTERVAL_TEMPERATURE,
+                byteArrayOf(0x00, 30, 0x02, 0x01)))
+        request = writer.commands.last()
+        assertArrayEquals(byteArrayOf(0x01, 0x00), request.copyOfRange(6, 8))
+
+        // Days 1..6 each single-packet → after day 6 the sync must finish (no new requests).
+        repeat(6) { day ->
+            engine.handleBigDataComplete(
+                ColmiCommandID.BIG_DATA_INTERVAL_TEMPERATURE,
+                bigData(ColmiCommandID.BIG_DATA_INTERVAL_TEMPERATURE,
+                    byteArrayOf((day + 1).toByte(), 30, 0x01, 0x00)))
+        }
+        val countAtEnd = writer.commands.size
+        assertArrayEquals("last request should have been day 6 packet 0",
+            byteArrayOf(0x06, 0x00), writer.commands.last().copyOfRange(6, 8))
+        // A stray re-emitted frame after DONE must be ignored (no request storm).
+        engine.handleBigDataComplete(
+            ColmiCommandID.BIG_DATA_INTERVAL_TEMPERATURE,
+            bigData(ColmiCommandID.BIG_DATA_INTERVAL_TEMPERATURE, byteArrayOf(0x06, 30, 0x01, 0x00)))
+        assertEquals(countAtEnd, writer.commands.size)
+        engine.destroy()
+    }
+
+    @Test
+    fun `interval temperature samples decode as centi-celsius on the interval grid`() {
+        // Header: day 1, interval 60 min, packetCount 1, packetIndex 0; samples 3626 → 36.26 °C
+        // and 0 → skipped.
+        val frame = bigData(ColmiCommandID.BIG_DATA_INTERVAL_TEMPERATURE, byteArrayOf(
+            0x01, 60, 0x01, 0x00,
+            (3626 and 0xFF).toByte(), (3626 shr 8).toByte(),
+            0x00, 0x00,
+        ))
+        val events = ColmiDecoder.decodeIntervalTemperature(frame, sampleOffset = 0, zone = zone)
+        assertEquals(1, events.size)
+        val sample = events.single() as RingDecodedEvent.TemperatureSample
+        assertEquals(36.26, sample.celsius, 0.001)
+        val expectedDay = LocalDate.now(zone).minusDays(1).atStartOfDay(zone).toInstant()
+        assertEquals(expectedDay, sample._timestamp)
+
+        // A later packet of the same day continues the slot grid via sampleOffset.
+        val offsetEvents = ColmiDecoder.decodeIntervalTemperature(frame, sampleOffset = 2, zone = zone)
+        val offsetSample = offsetEvents.single() as RingDecodedEvent.TemperatureSample
+        assertEquals(expectedDay.plusSeconds(2 * 60 * 60), offsetSample._timestamp)
+    }
+
+    // MARK: Multi-day SpO2 blocks
+
+    @Test
+    fun `spo2 decodes every 49-byte day block even when today comes first`() {
+        val day0 = ByteArray(49).also { it[0] = 0; it[1] = 96; it[2] = 98 }       // hour 0
+        val day1 = ByteArray(49).also { it[0] = 1; it[3] = 90; it[4] = 94 }       // hour 1
+        val events = ColmiDecoder.decodeBigData(
+            bigData(ColmiCommandID.BIG_DATA_SPO2, day0 + day1), zone = zone)
+        val spo2 = events.filterIsInstance<RingDecodedEvent.HistoryMeasurement>()
+            .filter { it.kind_field == MeasurementKind.SPO2 }
+        // The old loop stopped at the first daysAgo==0 block — day 1 was silently dropped.
+        assertEquals(2, spo2.size)
+        assertEquals(97.0, spo2[0].value, 0.01)
+        assertEquals(92.0, spo2[1].value, 0.01)
+    }
+
+    // MARK: Nap/lunch sleep (action 62)
+
+    @Test
+    fun `lunch sleep frames decode like regular sleep`() {
+        val start = 780; val end = 840   // 13:00 → 14:00 nap
+        val payload = byteArrayOf(
+            0x01, 0x00, 0x08,
+            (start and 0xFF).toByte(), ((start shr 8) and 0xFF).toByte(),
+            (end and 0xFF).toByte(), ((end shr 8) and 0xFF).toByte(),
+            ColmiCommandID.SLEEP_LIGHT.toByte(), 40,
+            ColmiCommandID.SLEEP_DEEP.toByte(), 20,
+        )
+        val events = ColmiDecoder.decodeBigData(
+            bigData(ColmiCommandID.BIG_DATA_SLEEP_LUNCH, payload), zone = zone)
+        val nap = events.single() as RingDecodedEvent.SleepTimeline
+        assertEquals(60, nap.stages.size)
+        assertEquals(40, nap.stages.count { it == SleepStage.LIGHT })
+        assertEquals(20, nap.stages.count { it == SleepStage.DEEP })
+    }
+
+    @Test
+    fun `lunch sleep completion does not advance the history pipeline`() {
+        val writer = RecordingWriter()
+        val engine = ColmiSyncEngine(writer, ColmiDecoder)
+        engine.runStartup()
+        val count = writer.commands.size
+        engine.handleBigDataComplete(ColmiCommandID.BIG_DATA_SLEEP_LUNCH)
+        assertEquals(count, writer.commands.size)
+        engine.destroy()
+    }
+
+    // MARK: Reassembly hardening
+
+    @Test
+    fun `continuation chunk starting with 0xBC does not restart the transfer`() {
+        val driver = ColmiDriver(RecordingWriter())
+        // Sleep frame whose payload contains 0xBC exactly at the chunk boundary:
+        // start = 0x05BC (1468 → wraps to 28 min past midnight via the >1440 branch).
+        val payload = byteArrayOf(
+            0x01, 0x00, 0x08,
+            0xBC.toByte(), 0x05,     // start u16 LE = 0x05BC
+            0x3C, 0x00,              // end = 60
+            ColmiCommandID.SLEEP_DEEP.toByte(), 30,
+            ColmiCommandID.SLEEP_REM.toByte(), 30,
+        )
+        val full = bigData(ColmiCommandID.BIG_DATA_SLEEP, payload)
+        val chunk1 = full.copyOfRange(0, 9)      // ends right before the 0xBC payload byte
+        val chunk2 = full.copyOfRange(9, full.size)  // starts with 0xBC — must be APPENDED
+        assertEquals(0xBC.toByte(), chunk2[0])
+
+        assertTrue(driver.ingest(chunk1, ColmiUUIDs.NOTIFY_V2).isEmpty())
+        val events = driver.ingest(chunk2, ColmiUUIDs.NOTIFY_V2)
+        val sleep = events.filterIsInstance<RingDecodedEvent.SleepTimeline>()
+        assertEquals("the split frame must reassemble into one sleep timeline", 1, sleep.size)
+        assertEquals(60, sleep.single().stages.size)
+    }
+}

--- a/app/src/test/java/com/pulseloop/ring/ColmiSleepSyncTest.kt
+++ b/app/src/test/java/com/pulseloop/ring/ColmiSleepSyncTest.kt
@@ -30,11 +30,11 @@ class ColmiSleepSyncTest {
     private fun emptyDayFrame(op: UByte): ByteArray = byteArrayOf(op.toByte(), 0xFF.toByte())
 
     /** Drive a just-started engine (stage ACTIVITY) to the SPO2 big-data stage by completing
-     *  every paged history day as empty: activity days 0..7, HR days 0..7, then stress. */
+     *  every paged history day as empty: activity days 0..7, HR days 0..7, stress days 0..6. */
     private fun driveToSpo2(engine: ColmiSyncEngine) {
         repeat(8) { engine.handleHistoryFrame(emptyDayFrame(ColmiCommandID.SYNC_ACTIVITY)) }
         repeat(8) { engine.handleHistoryFrame(emptyDayFrame(ColmiCommandID.SYNC_HEART_RATE)) }
-        engine.handleHistoryFrame(emptyDayFrame(ColmiCommandID.SYNC_STRESS))
+        repeat(7) { engine.handleHistoryFrame(emptyDayFrame(ColmiCommandID.SYNC_STRESS)) }
     }
 
     /** Continue from SPO2 to the terminal TEMPERATURE stage: spo2 → sleep → HRV days 0..6. */

--- a/app/src/test/java/com/pulseloop/ring/ColmiSleepSyncTest.kt
+++ b/app/src/test/java/com/pulseloop/ring/ColmiSleepSyncTest.kt
@@ -6,10 +6,14 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
- * On-demand sleep decoupling (QRing parity). Verifies that [ColmiSyncEngine.syncSleepNow] fires a
- * standalone `bigDataSleep()` request off the staged history pipeline, and that its completion does
- * NOT drive the pipeline into the next stage — while the normal in-pipeline sleep completion still
- * advances to HRV. Pure — a recording writer captures enqueued commands, no hardware.
+ * On-demand sleep decoupling (QRing parity) + history-pipeline termination.
+ *
+ * Verifies that [ColmiSyncEngine.syncSleepNow] fires a standalone `bigDataSleep()` request off the
+ * staged history pipeline and that its completion does NOT drive the pipeline into the next stage —
+ * while the normal in-pipeline sleep completion still advances to HRV. Also locks in the R10 sleep
+ * fixes: the New_Sleep_Protocol request frame bytes, and temperature as the terminal, idempotent
+ * history stage (no follow-up request the ring answers with a re-emitted frame — the 0x47 storm).
+ * Pure — a recording writer captures enqueued commands, no hardware.
  */
 class ColmiSleepSyncTest {
 
@@ -18,8 +22,40 @@ class ColmiSleepSyncTest {
         override fun enqueue(command: ByteArray) { commands.add(command) }
     }
 
-    /** `bc 27 01 00 ff 00 ff` — big-data V2 sleep request. */
+    /** `bc 27 02 00 81 80 ff 01` — big-data V2 New_Sleep_Protocol request. */
     private val sleepRequest = ColmiEncoder.bigDataSleep()
+
+    /** An "empty day" history reply (`packetNr = 0xFF`): completes the stage's current day so
+     *  [ColmiSyncEngine.handleHistoryFrame] advances the pipeline without decodable payload. */
+    private fun emptyDayFrame(op: UByte): ByteArray = byteArrayOf(op.toByte(), 0xFF.toByte())
+
+    /** Drive a just-started engine (stage ACTIVITY) to the SPO2 big-data stage by completing
+     *  every paged history day as empty: activity days 0..7, HR days 0..7, then stress. */
+    private fun driveToSpo2(engine: ColmiSyncEngine) {
+        repeat(8) { engine.handleHistoryFrame(emptyDayFrame(ColmiCommandID.SYNC_ACTIVITY)) }
+        repeat(8) { engine.handleHistoryFrame(emptyDayFrame(ColmiCommandID.SYNC_HEART_RATE)) }
+        engine.handleHistoryFrame(emptyDayFrame(ColmiCommandID.SYNC_STRESS))
+    }
+
+    /** Continue from SPO2 to the terminal TEMPERATURE stage: spo2 → sleep → HRV days 0..6. */
+    private fun driveSpo2ToTemperature(engine: ColmiSyncEngine) {
+        engine.handleBigDataComplete(ColmiCommandID.BIG_DATA_SPO2)
+        engine.handleBigDataComplete(ColmiCommandID.BIG_DATA_SLEEP)
+        repeat(7) { engine.handleHistoryFrame(emptyDayFrame(ColmiCommandID.SYNC_HRV)) }
+    }
+
+    @Test
+    fun `bigDataSleep builds the New_Sleep_Protocol frame byte-for-byte`() {
+        // QRing LargeDataHandler.addHeader(39, [0xFF, 0x01]): 0xBC, action 0x27, len=2 LE,
+        // CRC16/MODBUS([FF 01]) = 0x8081 LE, payload FF 01. The pre-fix 1-byte frame
+        // (bc 27 01 00 ff 00 ff) is silently ignored by the ring — sleep never syncs.
+        assertArrayEquals(
+            byteArrayOf(
+                0xBC.toByte(), 0x27, 0x02, 0x00, 0x81.toByte(), 0x80.toByte(), 0xFF.toByte(), 0x01
+            ),
+            ColmiEncoder.bigDataSleep()
+        )
+    }
 
     @Test
     fun `syncSleepNow from idle fires exactly the standalone sleep request`() {
@@ -62,8 +98,9 @@ class ColmiSleepSyncTest {
     fun `in-pipeline sleep completion still advances to HRV`() {
         val writer = RecordingWriter()
         val engine = ColmiSyncEngine(writer, ColmiDecoder)
-        engine.runStartup()               // sleepOnlyActive stays false; stage in pipeline
-        engine.handleBigDataComplete(ColmiCommandID.BIG_DATA_SPO2)   // drive the pipeline onto SLEEP
+        engine.runStartup()               // sleepOnlyActive stays false; stage = ACTIVITY
+        driveToSpo2(engine)               // reach SPO2 for real — stray completions are ignored
+        engine.handleBigDataComplete(ColmiCommandID.BIG_DATA_SPO2)   // SPO2 → SLEEP
         val countAfterSleepRequest = writer.commands.size
 
         engine.handleBigDataComplete(ColmiCommandID.BIG_DATA_SLEEP)  // normal pipeline sleep→hrv
@@ -86,6 +123,57 @@ class ColmiSleepSyncTest {
 
         assertEquals("stray sleep completion must not enqueue anything",
             countAfterStartup, writer.commands.size)
+        engine.destroy()
+    }
+
+    @Test
+    fun `a stray spo2 completion off the SPO2 stage does not jump the pipeline`() {
+        val writer = RecordingWriter()
+        val engine = ColmiSyncEngine(writer, ColmiDecoder)
+        engine.runStartup()               // stage = ACTIVITY
+        val countAfterStartup = writer.commands.size
+
+        // Rings can re-emit big-data frames outside their stage (the R10 did this with
+        // temperature); an unguarded SPO2 completion would reset the pipeline to SLEEP.
+        engine.handleBigDataComplete(ColmiCommandID.BIG_DATA_SPO2)
+
+        assertEquals("stray spo2 completion must not enqueue anything",
+            countAfterStartup, writer.commands.size)
+        engine.destroy()
+    }
+
+    @Test
+    fun `temperature completion is terminal - no follow-up request`() {
+        val writer = RecordingWriter()
+        val engine = ColmiSyncEngine(writer, ColmiDecoder)
+        engine.runStartup()
+        driveToSpo2(engine)
+        driveSpo2ToTemperature(engine)    // stage = TEMPERATURE, temperature request enqueued
+        val countAtTemperature = writer.commands.size
+
+        engine.handleBigDataComplete(ColmiCommandID.BIG_DATA_TEMPERATURE)
+
+        // Pre-fix this requested blood sugar (0x47), which Colmi rings answer by re-emitting
+        // the temperature frame — a request loop that congested the GATT queue (PR #26).
+        assertEquals("temperature completion must finish the sync, not request more",
+            countAtTemperature, writer.commands.size)
+        engine.destroy()
+    }
+
+    @Test
+    fun `a re-emitted temperature frame after the sync finished is ignored`() {
+        val writer = RecordingWriter()
+        val engine = ColmiSyncEngine(writer, ColmiDecoder)
+        engine.runStartup()
+        driveToSpo2(engine)
+        driveSpo2ToTemperature(engine)
+        engine.handleBigDataComplete(ColmiCommandID.BIG_DATA_TEMPERATURE)  // finishes the sync
+        val countAfterFinish = writer.commands.size
+
+        repeat(3) { engine.handleBigDataComplete(ColmiCommandID.BIG_DATA_TEMPERATURE) }
+
+        assertEquals("duplicate temperature completions must be idempotent",
+            countAfterFinish, writer.commands.size)
         engine.destroy()
     }
 

--- a/docs/qring-ble-adoption.md
+++ b/docs/qring-ble-adoption.md
@@ -124,7 +124,7 @@ gaps remained.
 **QRing bonds, gated on a capability bit.** After reading the device-support response it does:
 ```java
 // DeviceCmdInit.java
-if (deviceSupportFunctionRsp.supportBlePair) {   // = responseFrame[1] & 0x08
+if (deviceSupportFunctionRsp.supportBlePair) {   // = responseFrame[2] & 0x08 (see note)
     BleOperateManager.getInstance().bleCreateBond();   // BluetoothDevice.createBond()
 }
 ```
@@ -141,9 +141,14 @@ it never parsed `0x3C`. So the fix had to *teach PulseLoop to read `0x3C`* and r
 **The fix (implemented) — the "clean `supportBlePair` gate":**
 1. `ColmiCommandID.DEVICE_SUPPORT = 0x3C` + `ColmiEncoder.deviceSupport()` (opcode only,
    no sub-data — matches QRing's `DeviceSupportReq`).
-2. `ColmiDecoder.decodeDeviceSupport(frame)` → `Boolean?`: returns `frame[1] & 0x08`, or
-   `null` if it isn't a `0x3C` frame. **Fail-safe:** a wrong guess returns `null` → no bond
-   → today's behavior, never a crash.
+2. `ColmiDecoder.decodeDeviceSupport(frame)` → `ColmiDeviceSupport?`: `supportBlePair` =
+   `frame[2] & 0x08` and `supportIntervalTemp` = `frame[9] & 0x80`, or `null` if it isn't a
+   `0x3C` frame. **Fail-safe:** a wrong guess returns `null` → no bond → today's behavior,
+   never a crash. **OFFSET NOTE (bug fixed post-adoption):** QRing's `QCDataParser` strips
+   the opcode (and checksum) before any rsp class runs — `acceptData(copyOfRange(bArr, 1,
+   len-1))` — so `DeviceSupportFunctionRsp`'s `bArr[1]` is FULL-frame byte **2**, not 1.
+   The first port read `frame[1]`, a byte QRing never parses, so the bond gate keyed off
+   undefined data.
 3. `ColmiSyncEngine.runStartup` enqueues `deviceSupport()`; `handleRawNotify` decodes the
    reply *before* the config-seeding guard and, if `supportBlePair`, invokes a new
    `onBondRequested` callback.
@@ -250,8 +255,9 @@ The iOS app mirrors these classes (Swift). Apply the same behavior:
 
 iOS specifics to translate:
 - **Auto-HR:** same 8-byte payload. Trivial, no platform caveats.
-- **`0x3C` read + `supportBlePair`:** same decode (`frame[1] & 0x08`), same startup enqueue
-  and engine callback.
+- **`0x3C` read + `supportBlePair`:** same decode (`frame[2] & 0x08` — full-frame index;
+  QRing rsp classes see the opcode-stripped slice, so their `bArr[1]` = full-frame `[2]`),
+  same startup enqueue and engine callback.
 - **Bonding is different on iOS.** CoreBluetooth has **no `createBond()`** — bonding/pairing
   is triggered *implicitly* by accessing an encrypted characteristic, and the OS shows the
   pairing sheet. So the iOS equivalent of "honor `supportBlePair`" is usually a no-op at the
@@ -269,6 +275,8 @@ iOS specifics to translate:
 - `com/oudmon/ble/base/communication/rsp/HeartRateSettingRsp.java` — field semantics
 - `com/oudmon/ble/base/communication/req/DeviceSupportReq.java` — `0x3C` request (opcode 60)
 - `com/oudmon/ble/base/communication/rsp/DeviceSupportFunctionRsp.java` — `supportBlePair = byte[1] & 8`
+  of the opcode-stripped slice (`QCDataParser.java:34`) = **full-frame byte 2**; `supportIntervalTemp
+  = byte[8] & 0x80` = full-frame byte 9
 - `com/qcwireless/smart/ui/base/watch/DeviceCmdInit.java` — bond gate on `supportBlePair`
 - `com/oudmon/ble/base/bluetooth/BleBaseControl.java` — `bleCreateBond`, `connectGatt`,
   `mTimeoutRunnable` (40s), `mReconnectRunnable`, `refreshDeviceCache`


### PR DESCRIPTION
## Summary

Two stacked bugs kept sleep data from ever syncing on Colmi rings. Found and verified end-to-end on a **COLMI R10** (firmware `RT03CR_1.00.02`), driven from a diagnostics capture + the decompiled official QRing app.

## Bug 1 — malformed sleep request (the direct "no sleep" cause)

`ColmiEncoder.bigDataSleep()` sent a 1-byte payload (`bc 27 01 00 ff 00 ff`) that the ring **silently ignores**, so the sleep big-data query never got a reply — hence 0 nights ever recorded.

The official `New_Sleep_Protocol` (big-data action 39) requires a **2-byte payload `[0xFF, 0x01]`** (`0xFF` = all history, `0x01` = protocol version) framed with a real CRC16/MODBUS: `bc 27 02 00 81 80 ff 01`. Verified against QRing's `LargeDataHandler.addHeader(39, {0xFF, 0x01})` + `CRC16.calcCrc16`.

**After the fix the ring responds to the query** (confirmed live via logcat: `→ sleep request: bc2702008180ff01` → `← sleep reply: bc270100bf4000`, a valid CRC-checked frame reporting zero stored sleep days).

## Bug 2 — blood-sugar request storm (BLE congestion)

The history pipeline queried blood sugar (`0x47`) and blood pressure (`0x14`), which Colmi rings don't support (see `ColmiCoordinator.capabilities` and the `ColmiSyncEngine` class stage-order doc — the code had drifted from both). The ring answered the unsupported `0x47` by re-emitting its temperature frame, and `handleBigDataComplete(TEMPERATURE)` re-requested blood sugar on **every** temperature frame — an unguarded loop that fired ~70 requests and flooded the GATT queue with rejections, congesting the channel around sleep sync.

Fix: temperature is now the terminal history stage and its completion is **idempotent**; the BP and blood-sugar stages are removed. Confirmed live: `bc47` request count went from 70 → 0, GATT-rejection storm gone.

## Testing

- `:app:testDebugUnitTest` passes (incl. `ColmiSleepSyncTest`, `ColmiMeasurementSettingsTest`, `ColmiDecoderTest`).
- Signed release built and installed in place on a real Pixel 8 + COLMI R10; both fixes verified against live BLE traffic and fresh diagnostics exports.

## Note

The R10 currently reports **zero stored sleep records**, so the app correctly shows no sleep — this PR makes the request valid so real sleep data will sync once the ring has any. This Android code was ported from `ColmiSyncEngine.swift`/`ColmiEncoder.swift`; the same two bugs likely exist on iOS and should be fixed there for parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)