### PR TITLE
fix(ring): bond only the R09, make Disconnect stick, drop link on background

### DIFF
--- a/app/src/main/java/com/pulseloop/ring/RingBLEClient.kt
+++ b/app/src/main/java/com/pulseloop/ring/RingBLEClient.kt
@@ -658,6 +658,12 @@ class RingBLEClient(private val context: Context) {
         }
     }
 
+    /** True only when the connected model is one we deliberately OS-bond (currently the R09).
+     *  See [com.pulseloop.wearables.WearableModel.requiresOsBond]. */
+    private fun activeModelRequiresBond(): Boolean =
+        com.pulseloop.wearables.WearableModel.model(_state.value.activeWearableModelID)
+            ?.requiresOsBond == true
+
     /**
      * Create an OS-level bond with the connected ring — invoked by the sync engine only when
      * the ring's device-support reply advertises `supportBlePair` (Colmi R09 and newer). The
@@ -677,12 +683,6 @@ class RingBLEClient(private val context: Context) {
      * (no op in flight) avoids interrupting an active transfer; the wait is bounded, so a
      * long-running sync still bonds after [awaitOpsFlushed]'s timeout rather than never.
      */
-    /** True only when the connected model is one we deliberately OS-bond (currently the R09).
-     *  See [com.pulseloop.wearables.WearableModel.requiresOsBond]. */
-    private fun activeModelRequiresBond(): Boolean =
-        com.pulseloop.wearables.WearableModel.model(_state.value.activeWearableModelID)
-            ?.requiresOsBond == true
-
     private fun bondActiveDevice() {
         if (!hasPermissions()) return
         // Only bond the models that actually need it on Android (the R09). Every other ring

--- a/app/src/main/java/com/pulseloop/ring/RingBLEClient.kt
+++ b/app/src/main/java/com/pulseloop/ring/RingBLEClient.kt
@@ -240,6 +240,9 @@ class RingBLEClient(private val context: Context) {
         }
         val discoveredRing = _state.value.discovered.firstOrNull { it.id == id }
         connectingName = discoveredRing?.name ?: target.name
+        // Pairing/connecting a ring is an explicit user intent — clear any stay-off flag from a
+        // prior Disconnect so [connectLastKnown] isn't suppressed for this or the next session.
+        prefs.edit().remove(USER_DISCONNECTED_KEY).apply()
         resetReconnectBackoff()
         // Discovery's name-derived model wins over the carousel choice (iOS connect(to:selectedModelID:)).
         beginConnect(
@@ -259,6 +262,11 @@ class RingBLEClient(private val context: Context) {
      */
     fun connectLastKnown() {
         if (!bluetoothAdapter.isEnabled) return
+        // Honor a user-initiated Disconnect: stay off until the user reconnects ([userConnect])
+        // or pairs a new ring ([connectTo]). Every auto-reconnect path — foreground
+        // reconnectIfNeeded, the watchdog, and the background RingSyncWorker — funnels through
+        // here, so this one guard makes "Disconnect" actually stick.
+        if (prefs.getBoolean(USER_DISCONNECTED_KEY, false)) return
         val lastId = lastKnownIdentifier ?: return
         if (reconnectAttempts >= MAX_RECONNECT_ATTEMPTS) return
         // A still-pending reconnect scan means the last attempt never sighted the ring.
@@ -461,6 +469,41 @@ class RingBLEClient(private val context: Context) {
         updateState { copy(connectionState = RingConnectionState.DISCONNECTED) }
     }
 
+    /**
+     * User-initiated Disconnect (the Settings button). Unlike the transient [disconnect] used by
+     * the background worker and lifecycle, this makes the disconnect STICK: it sets a persisted
+     * flag that suppresses every auto-reconnect path until the user reconnects ([userConnect]) or
+     * pairs a new ring. For a model we OS-bond (the R09) it also removes the bond, since a bonded
+     * link can otherwise be held connected by the OS — the ring re-bonds (with the OS prompt) on
+     * the next user reconnect. Non-bonded models (R10 and the rest) just drop the link, matching
+     * the iOS "Disconnect" experience. The stored ring identity is kept either way, so the ring
+     * stays listed and one tap reconnects it; use [forget] to remove it entirely.
+     */
+    fun userDisconnect() {
+        prefs.edit().putBoolean(USER_DISCONNECTED_KEY, true).apply()
+        if (activeModelRequiresBond() && hasPermissions()) {
+            try {
+                bluetoothGatt?.device?.let { dev ->
+                    if (dev.bondState != BluetoothDevice.BOND_NONE) {
+                        Log.i("RingBLEClient", "User disconnect on a bonded ring — removing OS bond")
+                        dev::class.java.getMethod("removeBond").invoke(dev)
+                    }
+                }
+            } catch (e: Exception) {
+                Log.w("RingBLEClient", "removeBond on user disconnect failed: ${e.message}")
+            }
+        }
+        disconnect()
+    }
+
+    /** User-initiated reconnect (the "Reconnect last ring" button): clear the stay-off flag set
+     *  by [userDisconnect] and reconnect the stored ring. */
+    fun userConnect() {
+        prefs.edit().remove(USER_DISCONNECTED_KEY).apply()
+        resetReconnectBackoff()
+        connectLastKnown()
+    }
+
     /** Cache-refresh + close, swallowing the reflection/stack exceptions. */
     private fun closeGattQuietly(gatt: BluetoothGatt) {
         try { gatt::class.java.getMethod("refresh").invoke(gatt) } catch (_: Exception) {}
@@ -480,6 +523,7 @@ class RingBLEClient(private val context: Context) {
             .remove(LAST_PERIPHERAL_KEY)
             .remove(LAST_DEVICE_TYPE_KEY)
             .remove(LAST_WEARABLE_MODEL_KEY)
+            .remove(USER_DISCONNECTED_KEY)
             .apply()
 
         val gatt = bluetoothGatt
@@ -519,6 +563,7 @@ class RingBLEClient(private val context: Context) {
             .remove(LAST_PERIPHERAL_KEY)
             .remove(LAST_DEVICE_TYPE_KEY)
             .remove(LAST_WEARABLE_MODEL_KEY)
+            .remove(USER_DISCONNECTED_KEY)
             .apply()
         activeAdvertisedName = null
         updateState {
@@ -632,8 +677,22 @@ class RingBLEClient(private val context: Context) {
      * (no op in flight) avoids interrupting an active transfer; the wait is bounded, so a
      * long-running sync still bonds after [awaitOpsFlushed]'s timeout rather than never.
      */
+    /** True only when the connected model is one we deliberately OS-bond (currently the R09).
+     *  See [com.pulseloop.wearables.WearableModel.requiresOsBond]. */
+    private fun activeModelRequiresBond(): Boolean =
+        com.pulseloop.wearables.WearableModel.model(_state.value.activeWearableModelID)
+            ?.requiresOsBond == true
+
     private fun bondActiveDevice() {
         if (!hasPermissions()) return
+        // Only bond the models that actually need it on Android (the R09). Every other ring
+        // works GATT-only like iOS; bonding them just adds a pairing prompt and leaves the
+        // in-app Disconnect unable to release the link. QRing bonds every supportBlePair ring —
+        // we deliberately don't. A supportBlePair reply from any other model is a no-op here.
+        if (!activeModelRequiresBond()) {
+            Log.i("RingBLEClient", "Ring reports supportBlePair but this model works GATT-only — skipping bond")
+            return
+        }
         scope.launch {
             awaitOpsFlushed()
             // The link may have dropped while we waited for the queue to settle.
@@ -1294,6 +1353,9 @@ class RingBLEClient(private val context: Context) {
         private const val LAST_PERIPHERAL_KEY = "ring.lastPeripheralIdentifier"
         private const val LAST_DEVICE_TYPE_KEY = "ring.lastDeviceType"
         private const val LAST_WEARABLE_MODEL_KEY = "ring.lastWearableModel"
+        /** Set when the user taps Disconnect; suppresses every auto-reconnect path
+         *  (foreground, watchdog, background worker) until the user reconnects or re-pairs. */
+        private const val USER_DISCONNECTED_KEY = "ring.userDisconnected"
         /** How often the liveness watchdog runs. */
         private const val WATCHDOG_INTERVAL_MS = 15_000L
         /** No GATT activity for this long while CONNECTED ⇒ zombie link ⇒ reconnect.

--- a/app/src/main/java/com/pulseloop/ui/PulseLoopApp.kt
+++ b/app/src/main/java/com/pulseloop/ui/PulseLoopApp.kt
@@ -8,6 +8,9 @@ import androidx.compose.material.icons.outlined.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -41,6 +44,10 @@ import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.materials.ExperimentalHazeMaterialsApi
 import dev.chrisbanes.haze.materials.HazeMaterials
 import dev.chrisbanes.haze.rememberHazeState
+
+/** Grace period after the app is backgrounded before the live ring link is dropped for battery.
+ *  Long enough that a quick app-switch (glance at a notification) doesn't thrash the connection. */
+private const val BACKGROUND_DISCONNECT_GRACE_MS = 45_000L
 
 /**
  * Root composable — ported from PulseLoopApp.swift + RootViews.swift.
@@ -161,25 +168,46 @@ fun PulseLoopApp() {
             // confirmation-gated "Reseed Demo Data" button in Settings.
         }
 
-        // ── Auto-reconnect on return to foreground ───────────────────────
-        // When the phone wakes from idle, the OS may have silently torn down the GATT
-        // (Doze) without autoConnect recovering it. Re-attempt the link on every
-        // foreground transition so the user never has to force-close the app to reconnect.
-        // The first ON_START is handled by the LaunchedEffect above, so skip it here.
+        // ── Connection lifecycle on foreground/background ────────────────
+        // ON_START: re-attempt the link. The OS may have torn the GATT down during Doze
+        // (autoConnect=false won't recover it), so reconnect on every foreground so the user
+        // never has to force-close to reconnect. The first ON_START is handled by the
+        // LaunchedEffect above, so skip it here.
+        // ON_STOP: drop the live link a short grace period after backgrounding so the ring can
+        // sleep (a held-open link keeps the ~17mAh ring awake and blocks its advertising). This
+        // is a TRANSIENT disconnect — it does NOT set the user stay-off flag, so ON_START silently
+        // reconnects; the 30-min RingSyncWorker covers data while backgrounded. Skipped entirely
+        // while a workout is in progress, since that needs the live stream. The grace period is
+        // cancelled if the app returns to the foreground first, so quick app-switches don't thrash.
         val lifecycleOwner = LocalLifecycleOwner.current
+        val bgDisconnectScope = rememberCoroutineScope()
         DisposableEffect(lifecycleOwner) {
             var isFirstStart = true
+            var bgDisconnectJob: Job? = null
             val observer = LifecycleEventObserver { _, event ->
-                if (event == Lifecycle.Event.ON_START) {
-                    if (isFirstStart) {
-                        isFirstStart = false
-                    } else {
-                        bleClient.reconnectIfNeeded()
+                when (event) {
+                    Lifecycle.Event.ON_START -> {
+                        bgDisconnectJob?.cancel(); bgDisconnectJob = null
+                        if (isFirstStart) isFirstStart = false else bleClient.reconnectIfNeeded()
                     }
+                    Lifecycle.Event.ON_STOP -> {
+                        if (liveWorkout.state.value.activeSession != null) return@LifecycleEventObserver
+                        bgDisconnectJob?.cancel()
+                        // Default dispatcher so the timer fires while backgrounded (a UI-frame
+                        // clock would stall until the next foreground frame).
+                        bgDisconnectJob = bgDisconnectScope.launch(Dispatchers.Default) {
+                            delay(BACKGROUND_DISCONNECT_GRACE_MS)
+                            if (liveWorkout.state.value.activeSession == null) bleClient.disconnect()
+                        }
+                    }
+                    else -> {}
                 }
             }
             lifecycleOwner.lifecycle.addObserver(observer)
-            onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+            onDispose {
+                bgDisconnectJob?.cancel()
+                lifecycleOwner.lifecycle.removeObserver(observer)
+            }
         }
 
         // ── Navigation ───────────────────────────────────────────────────

--- a/app/src/main/java/com/pulseloop/ui/screens/SettingsSubScreens.kt
+++ b/app/src/main/java/com/pulseloop/ui/screens/SettingsSubScreens.kt
@@ -1117,7 +1117,7 @@ fun WearableSettingsScreen(
                     }
                     Spacer(Modifier.height(8.dp))
                     OutlinedButton(
-                        onClick = { bleClient?.disconnect() },
+                        onClick = { bleClient?.userDisconnect() },
                         modifier = Modifier.fillMaxWidth(),
                     ) {
                         Icon(Icons.Filled.Close, null, Modifier.size(16.dp))
@@ -1129,7 +1129,7 @@ fun WearableSettingsScreen(
                 ) {
                     Spacer(Modifier.height(12.dp))
                     OutlinedButton(
-                        onClick = { bleClient.connectLastKnown() },
+                        onClick = { bleClient.userConnect() },
                         modifier = Modifier.fillMaxWidth(),
                     ) {
                         Icon(Icons.Filled.Refresh, null, Modifier.size(16.dp))

--- a/app/src/main/java/com/pulseloop/wearables/WearableModel.kt
+++ b/app/src/main/java/com/pulseloop/wearables/WearableModel.kt
@@ -27,6 +27,16 @@ data class WearableModel(
     val advertisedNamePatterns: List<String>,
     /** Product image for this ring; when null, [com.pulseloop.ui.components.RingArtView] falls back to a generic ring. */
     @DrawableRes val imageRes: Int? = null,
+    /**
+     * Whether this model needs an OS-level bond (`createBond`) to hold a stable Android link.
+     * True only for models with a demonstrated GATT-only fragility — currently just the Colmi
+     * R09, which connects once then can't re-sync unless bonded (see docs/qring-ble-adoption.md
+     * §5a). Every other model works GATT-only exactly like iOS (which bonds nothing), so we
+     * leave them unbonded to avoid the pairing prompt and the "Disconnect doesn't release it"
+     * problem. Deliberately narrower than QRing, which bonds every `supportBlePair` ring.
+     * Expand this only when a model is shown to need it on real hardware.
+     */
+    val requiresOsBond: Boolean = false,
 ) {
     companion object {
         // "jring" is intentionally lowercase — that's how the brand styles its name.
@@ -42,7 +52,10 @@ data class WearableModel(
         val COLMI_R03 = colmi("colmi-r03", "Colmi R03", "Colmi", "^R03_.*", R.drawable.ring_colmi_r03)
         val COLMI_R06 = colmi("colmi-r06", "Colmi R06", "Colmi", "^R06_.*", R.drawable.ring_colmi_r06)
         val COLMI_R07 = colmi("colmi-r07", "Colmi R07", "Colmi", "^COLMI R07_.*", R.drawable.ring_colmi_r07)
-        val COLMI_R09 = colmi("colmi-r09", "Colmi R09", "Colmi", "^R09_.*", R.drawable.ring_colmi_r09)
+        // R09 is the one model that needs an OS bond to hold a stable Android link (see
+        // WearableModel.requiresOsBond).
+        val COLMI_R09 = colmi("colmi-r09", "Colmi R09", "Colmi", "^R09_.*", R.drawable.ring_colmi_r09,
+            requiresOsBond = true)
         val COLMI_R10 = colmi("colmi-r10", "Colmi R10", "Colmi", "^COLMI R10_.*", R.drawable.ring_colmi_r10)
         // The R11 shares its product art with the Yawell R11 (same hardware, same look).
         val COLMI_R11 = colmi("colmi-r11", "Colmi R11", "Colmi", "^R11C_[0-9A-F]{4}$", R.drawable.ring_yawell_r11)
@@ -60,11 +73,13 @@ data class WearableModel(
             brand: String,
             pattern: String,
             @DrawableRes imageRes: Int?,
+            requiresOsBond: Boolean = false,
         ) = WearableModel(
             id = id, displayName = name, brand = brand, family = RingDeviceType.COLMI_R02,
             tint = PulseColors.hrv, blurb = "HR · SpO₂ · HRV · Stress · Temp · Sleep",
             advertisedNamePatterns = listOf(pattern),
             imageRes = imageRes,
+            requiresOsBond = requiresOsBond,
         )
 
         /** Every supported model. The pairing screen groups by brand and sorts each tab alphabetically. */

--- a/app/src/test/java/com/pulseloop/ring/PairingMatchingTest.kt
+++ b/app/src/test/java/com/pulseloop/ring/PairingMatchingTest.kt
@@ -95,6 +95,25 @@ class PairingMatchingTest {
         }
     }
 
+    // ── OS-bond gating (only the R09 needs a bond on Android) ───────────
+
+    @Test
+    fun `only the R09 requires an OS bond`() {
+        assertTrue("R09 must require an OS bond", WearableModel.COLMI_R09.requiresOsBond)
+        // Every other catalog model works GATT-only like iOS — no bond, no pairing prompt.
+        val bonded = WearableModel.CATALOG.filter { it.requiresOsBond }.map { it.id }
+        assertEquals(listOf("colmi-r09"), bonded)
+    }
+
+    @Test
+    fun `bond decision resolves from the advertised name`() {
+        // The R09 advertises as R09_xxxx → gate bonds it; the R10 advertises as COLMI R10_xxxx
+        // → gate leaves it unbonded. This is exactly the input RingBLEClient.bondActiveDevice uses.
+        assertTrue(WearableModel.modelForAdvertisedName("R09_00AA")?.requiresOsBond == true)
+        assertFalse(WearableModel.modelForAdvertisedName("COLMI R10_xyz")?.requiresOsBond == true)
+        assertFalse(WearableModel.modelForAdvertisedName("R02_A1B2")?.requiresOsBond == true)
+    }
+
     @Test
     fun `detected model overrides carousel selection`() {
         val model = WearableModel.resolve(


### PR DESCRIPTION
## Summary

The `0x3C` bond-bit fix (PR #26) started OS-bonding **every** ring that reports `supportBlePair`, including the Colmi R10 — which surfaced an Android pairing prompt on connect and made the in-app "Disconnect" unable to release the ring (the OS held the bonded link / the app auto-reconnected).

Investigation against the decompiled official QRing app and the iOS source settled the right model:
- **QRing** bonds *all* `supportBlePair` rings with **no per-model gating**, and has only "Unbind/Forget" (removeBond) — no "pause" disconnect; a plain disconnect always auto-reconnects.
- **iOS** bonds **nothing** (no `createBond`, CoreBluetooth implicit pairing only) and has **zero per-model handling** — the whole Colmi line works GATT-only.

So the Android R09 bond is an **Android-specific workaround** for a GATT stack that can't otherwise hold the R09 link; no other model needs it. This PR narrows bonding to just the R09 and fixes the disconnect semantics.

## Changes

- **Bond only the R09.** `WearableModel.requiresOsBond` is true only for `colmi-r09`; `RingBLEClient.bondActiveDevice()` skips `createBond()` unless the resolved model needs it. The R10 and every other ring stay GATT-only like iOS — **no pairing prompt**. Deliberately narrower than QRing.
- **Disconnect now sticks** (`userDisconnect()`): sets a persisted stay-off flag enforced by a single guard in `connectLastKnown()`, which every auto-reconnect path (foreground, watchdog, 30‑min worker) funnels through. The ring stays off until the user taps "Reconnect last ring" (`userConnect()`) or re-pairs. For the bonded R09 it also `removeBond()`s (a bonded link can otherwise be held by the OS); the R09 re-bonds on the next user reconnect. Non-bonded rings just drop the link. **Forget** still clears everything.
- **Smart background disconnect:** `ON_STOP` drops the live link after a 45s grace (cancelled on quick return, skipped during a workout) so the ring can sleep between sessions; `ON_START` reconnects. This is transient — it never sets the stay-off flag or unpairs. The bond makes this safe for the R09 (fast, prompt-free reconnect).

## Testing

- Full unit suite **379/379** green; per-model bond decision covered in `PairingMatchingTest`.
- Signed release build installed on a physical Pixel + **COLMI R10** and verified: no pairing prompt on connect, Disconnect releases the ring and stays off, background link-drop + foreground reconnect behave as intended.

## Notes

- The BLE lifecycle paths are Android-framework-bound (can't be unit-tested); on-device validation on a real **R09** (bond still forms, disconnect unpairs + stays off, reconnect re-bonds) is still worth doing before relying on it in the wild.
- Disconnect is now **persistent for all rings** (stays off until reconnect), slightly beyond iOS's transient disconnect — chosen because a Disconnect that silently reconnects was the original complaint. Easy to switch the non-R09 rings back to iOS-transient if preferred.
- iOS parity follow-up: iOS's Disconnect is transient (reconnects on foreground); if the same "stay off" behavior is wanted there, it's a separate change in the root repo.
