### PR TITLE
fix(ring): restore R09/R11 bond allowlist, stop bonding the R10

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,40 @@
+# Agent instructions — PulseLoop Android
+
+Read this before touching ring/BLE hardware code (`app/src/main/java/com/pulseloop/ring/`,
+`app/src/main/java/com/pulseloop/wearables/`). Full detail: `docs/qring-ble-adoption.md`.
+
+## Ring BLE protocol work — match the vendor app, not iOS
+
+When porting or fixing a ring's BLE protocol (connect/pairing sequence, GATT characteristic
+writes, command framing, notification handling), reference the **decompiled official vendor
+Android app** (`decompiled-qring-official/`, `decompiled-jring-offical/`, etc., at the repo
+root) and match its actual behavior. Do not port iOS's CoreBluetooth sequencing — Android's
+Bluetooth stack behaves differently (pairing/bonding flow, MTU negotiation, background
+restrictions), and a straight iOS port has caused real pairing/data-collection bugs before.
+
+## Colmi/Yawell OS-bonding is a hand-curated allowlist — not "match QRing exactly"
+
+**This is the one rule in this file most likely to get silently reverted by a future "generalize
+to match the vendor app" fix. Read it before changing anything with "bond" in the name.**
+
+The real QRing app (`decompiled-qring-official/.../DeviceCmdInit.java`) bonds **unconditionally**
+whenever a ring's `0x3C` device-support reply sets `supportBlePair` — no per-model check.
+PulseLoop deliberately does **not** copy this. `RingBLEClient.bondActiveDevice()` also requires
+`WearableModel.requiresOsBond == true` for the resolved model — currently only `COLMI_R09`,
+`COLMI_R11`, `YAWELL_R11`. Every other Colmi/Yawell model (notably the **R10**, which also
+reports `supportBlePair`) stays GATT-only on purpose: bonding triggers a real OS pairing dialog
+and puts the ring in the phone's paired-devices list, a UX cost not worth paying for a model that
+already holds a stable link without it.
+
+**This has already regressed once in production**, in the same release: a 2026-07-19 fix for
+issue #29 (R11 stuck on "Connecting") removed the allowlist in favor of QRing's blanket rule,
+which fixed the R11 but reopened the R10 pairing-dialog bug that a 2026-07-15 commit had
+deliberately fixed by introducing the allowlist. Corrected by restoring the allowlist and adding
+R11/Yawell R11 to it by name.
+
+**The rule:** when a new model is confirmed (real hardware, or a specific credible user report)
+to need an OS bond, add it to `WearableModel.requiresOsBond`'s allowlist by name. Never widen
+the condition to "whenever `supportBlePair` is set" to match the vendor app — that is exactly
+the change that caused the regression, and it will cause it again for the R10.
+
+See `docs/qring-ble-adoption.md` §5a for the full history and the decompiled source references.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -19,7 +19,7 @@ android {
         // versionCode/versionName are overridable from Gradle properties so the release CI
         // can drive them straight from the git tag (e.g. -PappVersionCode=5 -PappVersionName=1.0.0).
         // Local builds fall back to the literals below.
-        versionCode = (project.findProperty("appVersionCode") as String?)?.toIntOrNull() ?: 18
+        versionCode = (project.findProperty("appVersionCode") as String?)?.toIntOrNull() ?: 19
         versionName = (project.findProperty("appVersionName") as String?) ?: "1.0.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/java/com/pulseloop/ring/RingBLEClient.kt
+++ b/app/src/main/java/com/pulseloop/ring/RingBLEClient.kt
@@ -485,15 +485,15 @@ class RingBLEClient(private val context: Context) {
      * User-initiated Disconnect (the Settings button). Unlike the transient [disconnect] used by
      * the background worker and lifecycle, this makes the disconnect STICK: it sets a persisted
      * flag that suppresses every auto-reconnect path until the user reconnects ([userConnect]) or
-     * pairs a new ring. If this ring is currently OS-bonded (see [bondActiveDevice]) it also
-     * removes the bond, since a bonded link can otherwise be held connected by the OS — the ring
+     * pairs a new ring. For a model we OS-bond (see [activeModelRequiresBond]) it also removes
+     * the bond, since a bonded link can otherwise be held connected by the OS — the ring
      * re-bonds (with the OS prompt) on the next user reconnect. Non-bonded rings just drop the
      * link, matching the iOS "Disconnect" experience. The stored ring identity is kept either
      * way, so the ring stays listed and one tap reconnects it; use [forget] to remove it entirely.
      */
     fun userDisconnect() {
         prefs.edit().putBoolean(USER_DISCONNECTED_KEY, true).apply()
-        if (hasPermissions()) {
+        if (activeModelRequiresBond() && hasPermissions()) {
             try {
                 bluetoothGatt?.device?.let { dev ->
                     if (dev.bondState != BluetoothDevice.BOND_NONE) {
@@ -670,16 +670,24 @@ class RingBLEClient(private val context: Context) {
         }
     }
 
+    /** True only when the connected model is one we deliberately OS-bond (currently the R09 and
+     *  the R11/Yawell R11). See [com.pulseloop.wearables.WearableModel.requiresOsBond]. */
+    private fun activeModelRequiresBond(): Boolean =
+        com.pulseloop.wearables.WearableModel.model(_state.value.activeWearableModelID)
+            ?.requiresOsBond == true
+
     /**
      * Create an OS-level bond with the connected ring — invoked by the sync engine only when
-     * the ring's device-support reply advertises `supportBlePair`. This now matches the official
-     * QRing app exactly: it bonds *every* ring that reports the bit, with no per-model
-     * allowlist (confirmed against the decompiled QRing sources, `DeviceCmdInit.init` —
-     * `if (deviceSupportFunctionRsp.supportBlePair) { ...; bleCreateBond() }`, unconditional on
-     * model). PulseLoop previously narrowed this to just the Colmi R09 (the one model it had
-     * confirmed needed it), which left other `supportBlePair` rings — e.g. the R11 — connecting
-     * GATT-only and, per user reports, stuck on "Connecting" with no stable link. Connecting
-     * GATT-only (no bond) is what left PulseLoop's users stuck cycling Bluetooth to recover.
+     * the ring's device-support reply advertises `supportBlePair` *and* the resolved model is on
+     * the [activeModelRequiresBond] allowlist (currently the R09 and R11/Yawell R11 — the models
+     * with demonstrated GATT-only fragility, R09 can't re-sync after the first connect, R11 gets
+     * stuck on "Connecting", issue #29). The official QRing app bonds *every* ring reporting the
+     * bit, with no per-model check at all (confirmed against the decompiled sources,
+     * `DeviceCmdInit.init` — `if (deviceSupportFunctionRsp.supportBlePair) { ...; bleCreateBond()
+     * }`). We deliberately don't copy that blanket behavior: it makes the OS pairing dialog pop
+     * for every `supportBlePair` model, including the R10, which doesn't need a bond to hold a
+     * stable link and where the prompt is a pure UX regression — see docs/qring-ble-adoption.md
+     * §5a. Expand the allowlist only when a specific model is shown to need it.
      *
      * Idempotent: skipped when already bonded/bonding, so it fires at most once per ring. Runs
      * after service discovery (the reply that triggers it arrives post-CONNECTED), so it does
@@ -695,6 +703,10 @@ class RingBLEClient(private val context: Context) {
      */
     private fun bondActiveDevice() {
         if (!hasPermissions()) return
+        if (!activeModelRequiresBond()) {
+            Log.i("RingBLEClient", "Ring reports supportBlePair but this model works GATT-only — skipping bond")
+            return
+        }
         scope.launch {
             awaitOpsFlushed()
             // The link may have dropped while we waited for the queue to settle.

--- a/app/src/main/java/com/pulseloop/wearables/WearableModel.kt
+++ b/app/src/main/java/com/pulseloop/wearables/WearableModel.kt
@@ -27,6 +27,17 @@ data class WearableModel(
     val advertisedNamePatterns: List<String>,
     /** Product image for this ring; when null, [com.pulseloop.ui.components.RingArtView] falls back to a generic ring. */
     @DrawableRes val imageRes: Int? = null,
+    /**
+     * Whether this model needs an OS-level bond (`createBond`) to hold a stable Android link.
+     * True only for models with demonstrated GATT-only fragility — the Colmi R09 (connects once
+     * then can't re-sync unless bonded) and the R11/Yawell R11 (same silicon, stuck on
+     * "Connecting" GATT-only — issue #29). Every other model works GATT-only exactly like iOS
+     * (which bonds nothing), so we leave them unbonded to avoid the pairing prompt — most
+     * notably the R10, which showed the OS pairing dialog when this gate was briefly dropped in
+     * favor of matching QRing's blanket `supportBlePair` bond. See docs/qring-ble-adoption.md
+     * §5a. Expand this only when a model is shown to need it on real hardware.
+     */
+    val requiresOsBond: Boolean = false,
 ) {
     companion object {
         // "jring" is intentionally lowercase — that's how the brand styles its name.
@@ -43,16 +54,22 @@ data class WearableModel(
         val COLMI_R06 = colmi("colmi-r06", "Colmi R06", "Colmi", "^R06_.*", R.drawable.ring_colmi_r06)
         val COLMI_R07 = colmi("colmi-r07", "Colmi R07", "Colmi", "^COLMI R07_.*", R.drawable.ring_colmi_r07)
         val COLMI_R08 = colmi("colmi-r08", "Colmi R08", "Colmi", "^R08_.*", R.drawable.ring_colmi_r08)
-        val COLMI_R09 = colmi("colmi-r09", "Colmi R09", "Colmi", "^R09_.*", R.drawable.ring_colmi_r09)
+        // R09 is one of two models that need an OS bond to hold a stable Android link (see
+        // WearableModel.requiresOsBond).
+        val COLMI_R09 = colmi("colmi-r09", "Colmi R09", "Colmi", "^R09_.*", R.drawable.ring_colmi_r09,
+            requiresOsBond = true)
         val COLMI_R10 = colmi("colmi-r10", "Colmi R10", "Colmi", "^COLMI R10_.*", R.drawable.ring_colmi_r10)
-        // The R11 shares its product art with the Yawell R11 (same hardware, same look).
-        val COLMI_R11 = colmi("colmi-r11", "Colmi R11", "Colmi", "^R11C_[0-9A-F]{4}$", R.drawable.ring_yawell_r11)
+        // The R11 shares its product art with the Yawell R11 (same hardware, same look) and the
+        // same OS-bond requirement (issue #29 — stuck on "Connecting" GATT-only).
+        val COLMI_R11 = colmi("colmi-r11", "Colmi R11", "Colmi", "^R11C_[0-9A-F]{4}$", R.drawable.ring_yawell_r11,
+            requiresOsBond = true)
         val COLMI_R12 = colmi("colmi-r12", "Colmi R12", "Colmi", "^COLMI R12_.*", R.drawable.ring_colmi_r12)
 
         // Yawell-branded variants
         val YAWELL_R05 = colmi("yawell-r05", "Yawell R05", "Yawell", "^R05_[0-9A-F]{4}$", R.drawable.ring_yawell_r05)
         val YAWELL_R10 = colmi("yawell-r10", "Yawell R10", "Yawell", "^R10_[0-9A-F]{4}$", R.drawable.ring_yawell_r10)
-        val YAWELL_R11 = colmi("yawell-r11", "Yawell R11", "Yawell", "^R11_[0-9A-F]{4}$", R.drawable.ring_yawell_r11)
+        val YAWELL_R11 = colmi("yawell-r11", "Yawell R11", "Yawell", "^R11_[0-9A-F]{4}$", R.drawable.ring_yawell_r11,
+            requiresOsBond = true)
         val H59 = colmi("h59", "H59 Ring", "H59", "^H59_.*", R.drawable.ring_h59)
 
         // YCBT protocol family (iOS #82): TK5 + Colmi/Yawell rings that ship with the
@@ -96,11 +113,13 @@ data class WearableModel(
             brand: String,
             pattern: String,
             @DrawableRes imageRes: Int?,
+            requiresOsBond: Boolean = false,
         ) = WearableModel(
             id = id, displayName = name, brand = brand, family = RingDeviceType.COLMI_R02,
             tint = PulseColors.hrv, blurb = "HR · SpO₂ · HRV · Stress · Temp · Sleep",
             advertisedNamePatterns = listOf(pattern),
             imageRes = imageRes,
+            requiresOsBond = requiresOsBond,
         )
 
         /** Every supported model. The pairing screen groups by brand and sorts each tab alphabetically. */

--- a/app/src/test/java/com/pulseloop/ring/PairingMatchingTest.kt
+++ b/app/src/test/java/com/pulseloop/ring/PairingMatchingTest.kt
@@ -100,6 +100,30 @@ class PairingMatchingTest {
         }
     }
 
+    // ── OS-bond gating (only the R09 and R11/Yawell R11 need a bond on Android) ───────────
+
+    @Test
+    fun `only the R09 and R11 require an OS bond`() {
+        assertTrue("R09 must require an OS bond", WearableModel.COLMI_R09.requiresOsBond)
+        assertTrue("R11 must require an OS bond", WearableModel.COLMI_R11.requiresOsBond)
+        assertTrue("Yawell R11 must require an OS bond", WearableModel.YAWELL_R11.requiresOsBond)
+        // Every other catalog model works GATT-only like iOS — no bond, no pairing prompt.
+        val bonded = WearableModel.CATALOG.filter { it.requiresOsBond }.map { it.id }.sorted()
+        assertEquals(listOf("colmi-r09", "colmi-r11", "yawell-r11"), bonded)
+    }
+
+    @Test
+    fun `bond decision resolves from the advertised name`() {
+        // The R09/R11 advertise as R09_xxxx/R11C_xxxx → gate bonds them; the R10 advertises as
+        // COLMI R10_xxxx → gate leaves it unbonded. This is exactly the input
+        // RingBLEClient.bondActiveDevice uses.
+        assertTrue(WearableModel.modelForAdvertisedName("R09_00AA")?.requiresOsBond == true)
+        assertTrue(WearableModel.modelForAdvertisedName("R11C_BEEF")?.requiresOsBond == true)
+        assertTrue(WearableModel.modelForAdvertisedName("R11_BEEF")?.requiresOsBond == true)
+        assertFalse(WearableModel.modelForAdvertisedName("COLMI R10_xyz")?.requiresOsBond == true)
+        assertFalse(WearableModel.modelForAdvertisedName("R02_A1B2")?.requiresOsBond == true)
+    }
+
     @Test
     fun `detected model overrides carousel selection`() {
         val model = WearableModel.resolve(

--- a/docs/qring-ble-adoption.md
+++ b/docs/qring-ble-adoption.md
@@ -34,7 +34,7 @@ which is NOT a Colmi ring and must never be affected by Colmi-specific changes.
 | PulseLoop driver | `ColmiDriver` / `ColmiSyncEngine` / `ColmiEncoder` / `ColmiDecoder` | `JringDriver` |
 | Framing | 16 bytes: 15 content + 1 checksum (`ColmiPacket.frame`) | identity / 20-byte |
 | Official app | QRing (`com.oudmon.ble`) | (other) |
-| Bonding | **Yes, if `supportBlePair`** | No (unencrypted) |
+| Bonding | **Only R09/R11 — see §5a**, not "whenever `supportBlePair`" (that's QRing's rule, not ours) | No (unencrypted) |
 
 **Key insight:** R09 is not a different protocol from R02 — it's the same opcodes on newer
 firmware (`RT09_*`) that is *stricter* about payload completeness and *expects* an OS bond.
@@ -170,9 +170,38 @@ it never parsed `0x3C`. So the fix had to *teach PulseLoop to read `0x3C`* and r
   `createBond()` only in a quiet gap — `createBond()` on a busy link can force a transient
   re-encrypt/disconnect on some firmware that would drop those in-flight ops.
 - **Idempotent:** guarded on `BOND_NONE`, so it bonds at most once per ring.
-- **Visible UX change (intended):** the ring now appears in the phone's Bluetooth
-  paired-devices list and lights the status-bar BT icon — this is the point, and matches
-  QRing. These rings use "just works" pairing (no passkey dialog).
+- **Visible UX change (intended, but ONLY for allowlisted models):** the ring appears in the
+  phone's Bluetooth paired-devices list and lights the status-bar BT icon — this is the point
+  for the R09/R11, and matches QRing for them. These rings use "just works" pairing (no
+  passkey dialog).
+
+> ### ⚠️ Bonding scope is a hand-curated allowlist — NOT "whenever `supportBlePair`"
+> **This is the single most re-litigated decision in this doc. Read it before touching
+> `bondActiveDevice()`, `WearableModel.requiresOsBond`, or anything with "bond" in the name.**
+>
+> The real QRing app (`DeviceCmdInit.init`, quoted above) bonds **unconditionally** whenever
+> the ring's `0x3C` reply sets `supportBlePair` — no per-model check at all. **PulseLoop
+> deliberately does not do this.** `RingBLEClient.bondActiveDevice()` also requires
+> `WearableModel.requiresOsBond == true` for the resolved model, currently just
+> `COLMI_R09`, `COLMI_R11`, `YAWELL_R11` — the models with a *demonstrated* GATT-only
+> fragility. Every other Colmi/Yawell model, including the **R10**, reports `supportBlePair`
+> too but stays GATT-only on purpose: bonding is a real UX cost (an OS pairing dialog, the
+> ring occupying the phone's paired-devices list) that isn't worth paying for a model that
+> already holds a stable link without it.
+>
+> **This has already regressed once.** 2026-07-15 (`0978636`) introduced the allowlist
+> specifically to stop the R10 from showing the pairing dialog. 2026-07-19 (`2e8412c`), a fix
+> for issue #29 (Colmi R11 stuck on "Connecting") removed the allowlist entirely in favor of
+> matching QRing's blanket rule — which fixed the R11 but immediately reopened the R10
+> pairing-dialog regression in the same release. Corrected by restoring the allowlist and
+> adding the R11/Yawell R11 to it **by name**, instead of widening the condition back to
+> `supportBlePair` alone.
+>
+> **The rule going forward:** when a new model is confirmed (real hardware, or a credible,
+> specific user report) to need an OS bond, add that model to the allowlist by name. Do
+> **not** "simplify" or "match QRing exactly" by conditioning on `supportBlePair` alone —
+> that generalization is exactly what caused the regression, and it will cause it again for
+> the R10 (or any other non-allowlisted model that happens to report the bit).
 
 ### 5b. Stuck on "Connecting…" forever (first pairing)
 **QRing arms a no-callback timeout on *every* connect** (`mTimeoutRunnable`, 40s in
@@ -199,7 +228,7 @@ write can't hang the connection; "toggle Bluetooth" hint after 2 sightless recon
 |---|---|---|---|
 | Auto-HR write | 7-field `0x16` | 4-byte `0x16` (truncated) | **7-field `0x16`** |
 | Reads capabilities (`0x3C`) | yes | no | **yes** |
-| OS bond | if `supportBlePair` | never | **if `supportBlePair`** |
+| OS bond | if `supportBlePair` (any model) | never | **if `supportBlePair` AND model on the [allowlist](#5a-no-os-bond-the-main-pairing-defect) (R09/R11)** |
 | First-pair connect timeout | 40s, every attempt | none (gated out) | **30s, every attempt** |
 | Reconnect timeout | 40s | 30s (reconnect only) | 30s (reconnect only) |
 | `connectGatt` params | `false`, `TRANSPORT_LE` | same | same |


### PR DESCRIPTION
## Summary
- Last night's fix for issue #29 (Colmi R11 stuck on "Connecting") removed `WearableModel.requiresOsBond` entirely and matched QRing's blanket "bond whenever `supportBlePair` is set" rule. That fixed the R11 but reopened a previously-fixed regression: the R10 also reports `supportBlePair`, so it started showing the OS pairing dialog again — a 2026-07-15 commit had deliberately suppressed that via a per-model allowlist.
- Restores `requiresOsBond` as a hand-curated allowlist covering `COLMI_R09`, `COLMI_R11`, and `YAWELL_R11` (same silicon as the Colmi R11, different brand name), instead of reverting to blanket `supportBlePair` matching. Every other Colmi/Yawell model, including the R10, stays GATT-only with no pairing prompt, matching iOS.
- Adds `AGENTS.md`/`CLAUDE.md` so this rule is visible to any agent working in this repo, and updates `docs/qring-ble-adoption.md` (already written for an AI-agent audience) with the allowlist history so a future "just match the vendor app" fix doesn't regress this a third time.

## Test plan
- [x] `./gradlew testDebugUnitTest` — full suite green, including restored/expanded `PairingMatchingTest` bond-gate cases (R09/R11/Yawell R11 bonded, R10/R02/etc. not)
- [ ] On-device: pair an R10 and confirm no OS pairing dialog appears
- [ ] On-device: pair an R09/R11 and confirm the pairing dialog still appears and the link stays stable