### PR TITLE
fix(ring): stop Jring from claiming Colmi R11 rings advertising SMART_RING

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -19,7 +19,7 @@ android {
         // versionCode/versionName are overridable from Gradle properties so the release CI
         // can drive them straight from the git tag (e.g. -PappVersionCode=5 -PappVersionName=1.0.0).
         // Local builds fall back to the literals below.
-        versionCode = (project.findProperty("appVersionCode") as String?)?.toIntOrNull() ?: 19
+        versionCode = (project.findProperty("appVersionCode") as String?)?.toIntOrNull() ?: 20
         versionName = (project.findProperty("appVersionName") as String?) ?: "1.0.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/java/com/pulseloop/ring/JringDriver.kt
+++ b/app/src/main/java/com/pulseloop/ring/JringDriver.kt
@@ -12,7 +12,13 @@ object JringCoordinator : WearableCoordinator {
     private const val MANUFACTURER_HEX_NEEDLE = "41422ec75b6a"
 
     override fun matches(name: String?, advertisement: AdvertisementInfo): Boolean {
-        if (name == ADVERTISED_NAME) return true
+        // "SMART_RING" isn't exclusive to real Jring hardware — some Colmi/Yawell R11 units
+        // (issue #29) advertise this same generic factory name while still exposing Colmi's own
+        // GATT service UUIDs. Don't let the bare name win over a device that already identifies
+        // itself as Colmi/Yawell via service UUID; ColmiCoordinator gets first claim on those.
+        val advertisesColmiService = advertisement.serviceUUIDs.contains(ColmiUUIDs.SERVICE_V1) ||
+            advertisement.serviceUUIDs.contains(ColmiUUIDs.SERVICE_V2)
+        if (name == ADVERTISED_NAME && !advertisesColmiService) return true
         if (advertisement.serviceUUIDs.contains(RingUUIDs.SERVICE)) return true
         advertisement.manufacturerData?.let { mfg ->
             if (mfg.toHexString().contains(MANUFACTURER_HEX_NEEDLE)) return true

--- a/app/src/test/java/com/pulseloop/ring/PairingMatchingTest.kt
+++ b/app/src/test/java/com/pulseloop/ring/PairingMatchingTest.kt
@@ -64,6 +64,21 @@ class PairingMatchingTest {
     }
 
     @Test
+    fun `jring does not claim SMART_RING when the device also advertises a colmi service (issue 29)`() {
+        // Some Colmi/Yawell R11 units advertise the generic factory name "SMART_RING" while
+        // still exposing Colmi's own GATT service UUIDs. JringCoordinator must defer to
+        // ColmiCoordinator for those instead of claiming the device by name alone.
+        val colmiV1 = AdvertisementInfo(listOf(ColmiUUIDs.SERVICE_V1), null)
+        val colmiV2 = AdvertisementInfo(listOf(ColmiUUIDs.SERVICE_V2), null)
+        assertFalse(JringCoordinator.matches("SMART_RING", colmiV1))
+        assertFalse(JringCoordinator.matches("SMART_RING", colmiV2))
+        assertTrue(ColmiCoordinator.matches("SMART_RING", colmiV1))
+        assertTrue(ColmiCoordinator.matches("SMART_RING", colmiV2))
+        // A genuine Jring device (no Colmi service present) is unaffected.
+        assertTrue(JringCoordinator.matches("SMART_RING", noAdv))
+    }
+
+    @Test
     fun `catalog families all have a registered coordinator`() {
         val registeredTypes = setOf(
             JringCoordinator.deviceType, ColmiCoordinator.deviceType,


### PR DESCRIPTION
## Summary
- Fixes #29 (and matches the follow-up reports from other users where a Colmi R11/R02 gets stuck on "Connecting" and diagnostics show it misidentified as `JRING`/`SMART_RING`).
- `JringCoordinator.matches()` (`JringDriver.kt`) treated an exact advertised-name match of `"SMART_RING"` as sufficient on its own to claim a device — no check against Colmi's own service UUIDs. Since `JringCoordinator` is listed first in `RingBLEClient.coordinators` and matching is first-match-wins, any Colmi/Yawell ring that happens to advertise the literal name `"SMART_RING"` (confirmed on real R11 hardware via two users' diagnostics) got permanently routed to the Jring protocol driver before `ColmiCoordinator`'s service-UUID check ever ran — leaving it connected under the wrong protocol until the 30s connect-timeout gives up.
- Fix: `JringCoordinator` now defers to `ColmiCoordinator` when the device's advertisement already includes `ColmiUUIDs.SERVICE_V1`/`SERVICE_V2`. Real Jring hardware (no Colmi service UUIDs present) is unaffected. No other ring's coordinator/matching logic changed.
- Verified against the decompiled official QRing app (`decompiled-qring-official/`) per this repo's `AGENTS.md` convention: QRing's own device classification is name-prefix based against a **live server-fetched allowlist**, which we can't replicate from static analysis — so this fix intentionally does not claim exact vendor parity, and instead closes the gap using our own already-existing Colmi service-UUID signal (`ColmiUUIDs.SERVICE_V1`/`SERVICE_V2`), which is verified present in the affected hardware via the reporter's diagnostics.
- This composes correctly with the R09/R11 OS-bond allowlist (#32): once `ColmiCoordinator` wins, `WearableModel.resolve()` resolves to `COLMI_R11`/`YAWELL_R11` (via the user's carousel selection during first pairing), which already has `requiresOsBond = true`.

## Known limitation
One of the two reported devices' diagnostics only show *post-connect* GATT services (which don't include Colmi's UUIDs, likely because that capture happened after the device was already misrouted through the wrong protocol) — we don't have its raw pre-connect advertisement, since diagnostics don't currently capture that (`rawPackets` exists in the export schema but isn't wired up). This fix is expected to resolve it based on the same root cause, but isn't independently confirmed for that specific device.

## Test plan
- [x] `./gradlew testDebugUnitTest` — full suite green, including a new regression test (`jring does not claim SMART_RING when the device also advertises a colmi service (issue 29)`)
- [ ] On-device: confirm a Colmi R11 advertising "SMART_RING" now pairs and connects successfully