### PR TITLE
fix(sleep): stop the Sleep tab hypnogram from collapsing mid-sync

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -19,7 +19,7 @@ android {
         // versionCode/versionName are overridable from Gradle properties so the release CI
         // can drive them straight from the git tag (e.g. -PappVersionCode=5 -PappVersionName=1.0.0).
         // Local builds fall back to the literals below.
-        versionCode = (project.findProperty("appVersionCode") as String?)?.toIntOrNull() ?: 20
+        versionCode = (project.findProperty("appVersionCode") as String?)?.toIntOrNull() ?: 21
         versionName = (project.findProperty("appVersionName") as String?) ?: "1.0.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/java/com/pulseloop/service/EventPersistenceSubscriber.kt
+++ b/app/src/main/java/com/pulseloop/service/EventPersistenceSubscriber.kt
@@ -1,5 +1,6 @@
 package com.pulseloop.service
 
+import androidx.room.withTransaction
 import com.pulseloop.data.PulseLoopDatabase
 import com.pulseloop.data.entity.*
 import com.pulseloop.ring.*
@@ -398,18 +399,26 @@ class EventPersistenceSubscriber(
      * change signal: Room's reactive Flows (SleepViewModel observes `recentFlow`) already refresh
      * the UI on any sleep-table write, and sleep is cleared + rebuilt from the ring on every connect
      * anyway — there is no unchanged-day re-sync to optimize away.
+     *
+     * Wrapped in one transaction: the body below deletes every existing row's blocks up front, then
+     * re-upserts sessions and re-inserts blocks per segment one write at a time. Without a
+     * transaction, each per-segment session upsert fires `recentFlow` mid-reconcile, and
+     * SleepViewModel re-reads blocks for a session that's only partially rewritten — the sleep
+     * architecture chart transiently renders with just the first few (chronologically-earliest)
+     * blocks before the rest land. `db.withTransaction` defers the Flow's invalidation until commit,
+     * so observers only ever see the fully-reconciled state (matches DemoDataSeeder's usage).
      */
     private suspend fun reconcileWakingDay(
         dayStart: Long,
         existing: List<SleepSessionEntity>,
         dayBlocks: List<SleepStageBlockEntity>,
-    ) {
+    ) = db.withTransaction {
         val groups = SleepSegmentation.segment(dayBlocks)
 
         // No blocks left on this day — drop the empty rows entirely (their blocks cascade).
         if (groups.isEmpty()) {
             existing.forEach { db.sleepSessionDao().deleteById(it.id) }
-            return
+            return@withTransaction
         }
 
         data class Segment(val blocks: List<SleepStageBlockEntity>, val start: Long, val end: Long)


### PR DESCRIPTION
## Summary
- Root-caused from a screen recording showing the Sleep tab's hypnogram render the full night (score 91 "Excellent"), then collapse a moment later to just the first hour or so of stages (score dropping to 60 "Fair") while still on the same day/session — no navigation involved.
- `EventPersistenceSubscriber.reconcileWakingDay()` deletes a waking day's existing sleep blocks up front, then re-upserts the session row and re-inserts that segment's blocks, **per segment, sequentially** — with no surrounding transaction. Each per-segment `sleepSessionDao().upsert()` fires Room's `sleep_sessions` table invalidation, which `SleepViewModel` observes live via `recentFlow(7)` and immediately re-reads blocks for. Since blocks reinsert in chronological order, a rebuild triggered mid-reconcile catches only whichever early blocks have landed so far — exactly the "renders, then collapses" behavior, plus a mismatched score (the Sleep tab's hero card independently recomputes score from the transient `blocks` list it sees, rather than using the reconciler's own correctly-computed `session.score`).
- Fix: wrap `reconcileWakingDay`'s body in `db.withTransaction { ... }` — the same pattern `DemoDataSeeder.kt` already uses for its own delete+upsert+insert sequence. This defers the `sleep_sessions` Flow's invalidation until the whole reconcile commits, so observers only ever see the fully-reconciled state.
- Also bumps versionCode to 21.

## Test plan
- [x] `./gradlew testDebugUnitTest` — full suite green (no existing test covers this path — it needs a real/in-memory Room DB, and this project's unit tests are all pure-logic by convention, same as the BLE-dependent code)
- [ ] On-device: connect a real ring while watching the Sleep tab during an active sync and confirm the hypnogram no longer visibly collapses/flickers mid-sync