### PR TITLE
fix(ring): connect the Colmi R11 (SMART_RING) via the Colmi driver, not jring

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -19,7 +19,7 @@ android {
         // versionCode/versionName are overridable from Gradle properties so the release CI
         // can drive them straight from the git tag (e.g. -PappVersionCode=5 -PappVersionName=1.0.0).
         // Local builds fall back to the literals below.
-        versionCode = (project.findProperty("appVersionCode") as String?)?.toIntOrNull() ?: 21
+        versionCode = (project.findProperty("appVersionCode") as String?)?.toIntOrNull() ?: 22
         versionName = (project.findProperty("appVersionName") as String?) ?: "1.0.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/java/com/pulseloop/ring/RingBLEClient.kt
+++ b/app/src/main/java/com/pulseloop/ring/RingBLEClient.kt
@@ -256,11 +256,31 @@ class RingBLEClient(private val context: Context) {
         // prior Disconnect so [connectLastKnown] isn't suppressed for this or the next session.
         prefs.edit().remove(USER_DISCONNECTED_KEY).apply()
         resetReconnectBackoff()
-        // Discovery's name-derived model wins over the carousel choice (iOS connect(to:selectedModelID:)).
+
+        // Normally discovery's name-derived family wins over the carousel choice
+        // (iOS connect(to:selectedModelID:)). The exception (issue #29): several Colmi/Yawell
+        // rings — notably the R11 — advertise the generic BLE name "SMART_RING", which the
+        // scanner can only classify as JRING because that name isn't exclusive to jring hardware
+        // and they don't advertise their Colmi service UUID pre-connect. When the user has
+        // explicitly picked a NON-jring model in the pairing carousel, trust that pick over a
+        // generic-JRING detection: drive the connection with the selected model's coordinator
+        // (and, for the R11, its OS bond) instead of the jring driver, which can't find its
+        // 000056ff characteristics on a Colmi ring and hangs the connect forever. A *confident*
+        // scan match (a specific Colmi name pattern, or the 000056ff jring service UUID) still
+        // resolves to its own family and is unaffected — we only override the JRING fallback.
+        val detectedType = discoveredRing?.deviceType
+        val selectedModel = com.pulseloop.wearables.WearableModel.model(selectedModelID)
+        val honorSelection = detectedType == RingDeviceType.JRING &&
+            selectedModel != null && selectedModel.family != RingDeviceType.JRING
+        if (honorSelection) {
+            Log.i("RingBLEClient", "Ring detected as JRING (generic \"SMART_RING\" name) but user " +
+                "selected ${selectedModel!!.displayName} — honoring the carousel choice")
+        }
         beginConnect(
             target,
-            discoveredRing?.deviceType,
-            selectedModelID = discoveredRing?.wearableModelID ?: selectedModelID,
+            if (honorSelection) selectedModel!!.family else detectedType,
+            selectedModelID = if (honorSelection) selectedModelID
+                else discoveredRing?.wearableModelID ?: selectedModelID,
             advertisedName = discoveredRing?.name ?: target.name,
         )
     }
@@ -1088,6 +1108,34 @@ class RingBLEClient(private val context: Context) {
                         ))
                     }
                 } catch (_: Exception) {}
+            }
+
+            // Post-connect re-route (issue #29): a Colmi R11 that advertised the generic name
+            // "SMART_RING" with no Colmi service UUID in its advertisement gets classified as
+            // JRING by the scanner, so the jring driver is installed — but the jring driver's
+            // 000056ff characteristics don't exist on this ring, so the binding loop below would
+            // find nothing, no notify CCCD write is enqueued, and the connect hangs (30s watchdog
+            // → disconnect → retry loop). The ring's real Colmi service only becomes visible now,
+            // post-connect, in the GATT table. If we see it while running the jring driver, swap
+            // to the Colmi coordinator so the correct characteristics bind below and the R11 gets
+            // its OS bond. Scoped to JRING → Colmi only, so YCBT/TK5/etc. are never affected.
+            val hasColmiService = gatt.services.any {
+                val u = it.uuid.toString()
+                u == ColmiUUIDs.SERVICE_V1 || u == ColmiUUIDs.SERVICE_V2
+            }
+            if (hasColmiService && activeCoordinator?.deviceType == RingDeviceType.JRING) {
+                Log.i("RingBLEClient", "Discovered Colmi services under the jring driver — " +
+                    "re-routing to the Colmi driver")
+                installDriver(ColmiCoordinator)
+                // Re-resolve the model against the Colmi family so bonding is evaluated correctly.
+                // If the user picked a Colmi model in the carousel it's honored; otherwise the
+                // generic R02 base is used (requiresOsBond = false, so no speculative bond prompt).
+                val remodel = com.pulseloop.wearables.WearableModel.resolve(
+                    advertisedName = activeAdvertisedName,
+                    selectedModelID = _state.value.activeWearableModelID,
+                    family = RingDeviceType.COLMI_R02,
+                )?.id ?: com.pulseloop.wearables.WearableModel.COLMI_R02.id
+                updateState { copy(activeWearableModelID = remodel) }
             }
 
             val driver = activeDriver ?: return


### PR DESCRIPTION
## Summary
Root-caused from two users' build-20 diagnostics on issue #29. The complaint is a hard **connect-then-hang loop**, not a cosmetic mislabel — and build 20 (the scan-UUID detection fix) behaves identically to build 19 for these rings.

**The chain:**
1. The R11 advertises the generic BLE name `SMART_RING` with **no Colmi service UUID in its advertisement**, so `matchDeviceType` classifies it as `JRING` and `beginConnect` installs the jring driver.
2. The user's explicit "Colmi R11" carousel pick was discarded — `connectTo` passed the scan-detected `deviceType` (JRING) straight through (*"Discovery's name-derived model wins over the carousel choice"*).
3. `onServicesDiscovered` binds write/notify characteristics only under the active driver's service UUIDs (jring's `000056ff`). The ring exposes no `56ff` service, so nothing binds and **no notify CCCD write is enqueued**.
4. The `CONNECTED` transition fires only on a notify-CCCD write completing — so it never fires. 30s watchdog → `Connect attempt hung` → disconnect → retry loop, forever.

The build-20 gate (PR #33) keyed on the Colmi UUID being in the **scan advertisement**, but it isn't — it only shows up **post-connect** in the GATT table (`6e40fff0` / `de5bf728`), confirming the exact limitation flagged when #33 shipped.

## Fixes (both, complementary)
- **(A) Honor the user's carousel pick** over a generic-JRING detection (`connectTo`): when a ring is classified JRING purely from the shared `SMART_RING` name and the user explicitly selected a non-jring model, drive the connection with the selected model's coordinator — and, for the R11, trigger its OS bond. Confident scan matches (a specific Colmi name pattern, or the `000056ff` jring service) still win; only the JRING fallback is overridden.
- **(B) Post-connect re-route** safety net (`onServicesDiscovered`): if the jring driver is active but discovery reveals a Colmi service (`6e40fff0` / `de5bf728`), swap to the Colmi coordinator and re-resolve the model so the correct characteristics bind and the link completes. Scoped **JRING → Colmi only**, so YCBT/TK5/etc. are untouched. This catches the case where the user didn't pick a Colmi model in the carousel.

## Scope / known limitation
- This fully addresses **jcspradley's** ring, whose GATT exposes the Colmi UART profile (`6e40fff0`/`de5bf728`, firmware `RT02CR_3.12.00_251205`).
- **zaggash's** ring is a different profile — GATT exposes only `180d`/`180f`/`fdda`/`fdd7`, no Colmi UART service, and he has never seen the bond popup. Leading hypothesis: the R11 gates its full Colmi profile behind an OS bond, and his (unbonded) ring only exposes the limited profile. A+B correctly classify it and attempt the bond, but if the profile is truly bond-gated it needs the bond to land first. Being followed up on the ticket (asking him to bond via phone Bluetooth settings, like jcspradley, and re-capture) — the raw pre-connect advertisement still isn't captured (`rawPackets` is unwired), so this is the cleanest confirmation path.

## Test plan
- [x] `./gradlew testDebugUnitTest` — full suite green (this path needs a live BLE/GATT stack; no unit harness exists for it, per repo convention)
- [ ] On-device (jcspradley-class R11): select "Colmi R11", tap the SMART_RING device, confirm it connects (driven by the Colmi driver), shows the pairing prompt, and holds a stable link
- [ ] On-device: confirm a genuine jring still connects unchanged