### PR TITLE
Colmi R11 (CRP) vitals: decode fix + Measure button SpO2 + all-day history pull

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -19,7 +19,7 @@ android {
         // versionCode/versionName are overridable from Gradle properties so the release CI
         // can drive them straight from the git tag (e.g. -PappVersionCode=5 -PappVersionName=1.0.0).
         // Local builds fall back to the literals below.
-        versionCode = (project.findProperty("appVersionCode") as String?)?.toIntOrNull() ?: 23
+        versionCode = (project.findProperty("appVersionCode") as String?)?.toIntOrNull() ?: 24
         versionName = (project.findProperty("appVersionName") as String?) ?: "1.0.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/java/com/pulseloop/ring/CRPCoordinator.kt
+++ b/app/src/main/java/com/pulseloop/ring/CRPCoordinator.kt
@@ -27,16 +27,19 @@ object CRPCoordinator : WearableCoordinator {
     }
 
     /**
-     * v1 baseline — only capabilities backed by a decode path confirmed from the decompile:
-     * current-steps push (`fdd1`), the standard HR stream (`2a37`) with its start/stop command,
-     * the standard battery read, plus find-device and factory-reset commands. Sleep / SpO2 / HRV /
-     * stress / temperature and history sync are deferred until their CRP reply layouts are
-     * confirmed against hardware — deliberately not promised here so the product UI hides them.
+     * Real-time vital capabilities backed by decoded group-1 replies (`g1/a.java` lines 664–712):
+     * HR (cmd 9), HRV (cmd 10), SpO2 (cmd 11), stress (cmd 14), temperature (cmd 32).
+     * History sync and sleep are still deferred — their group-7 reply layouts aren't confirmed
+     * against hardware yet. Steps push (`fdd1`), battery (`2a19`), find-device and factory-reset
+     * also confirmed. Note: HR does NOT use the standard `2a37` characteristic on CRP rings —
+     * all vital results come back as framed replies on `fdd3` group 1.
      */
     override val capabilities = setOf(
         WearableCapability.STEPS, WearableCapability.REALTIME_STEPS,
         WearableCapability.HEART_RATE, WearableCapability.REALTIME_HEART_RATE,
         WearableCapability.MANUAL_HEART_RATE,
+        WearableCapability.SPO2, WearableCapability.STRESS, WearableCapability.HRV,
+        WearableCapability.TEMPERATURE,
         WearableCapability.BATTERY,
         WearableCapability.FIND_DEVICE, WearableCapability.FACTORY_RESET,
     )

--- a/app/src/main/java/com/pulseloop/ring/CRPCoordinator.kt
+++ b/app/src/main/java/com/pulseloop/ring/CRPCoordinator.kt
@@ -37,7 +37,7 @@ object CRPCoordinator : WearableCoordinator {
     override val capabilities = setOf(
         WearableCapability.STEPS, WearableCapability.REALTIME_STEPS,
         WearableCapability.HEART_RATE, WearableCapability.REALTIME_HEART_RATE,
-        WearableCapability.MANUAL_HEART_RATE,
+        WearableCapability.MANUAL_HEART_RATE, WearableCapability.MANUAL_SPO2,
         WearableCapability.SPO2, WearableCapability.STRESS, WearableCapability.HRV,
         WearableCapability.TEMPERATURE,
         WearableCapability.BATTERY,

--- a/app/src/main/java/com/pulseloop/ring/CRPDecoder.kt
+++ b/app/src/main/java/com/pulseloop/ring/CRPDecoder.kt
@@ -97,52 +97,41 @@ object CRPDecoder {
     }
 
     /**
-     * Decode group-1 vital result replies. Confirmed against `g1/a.java` and `e1/f.java` (HR),
-     * `e1/g.java` (HRV), `e1/d.java` (SpO2), `e1/h.java` (stress/physical strength), and
-     * the vendor's `onMeasureComplete` flow for temperature (cmd 32).
-     *
-     * Layout: `payload[0]` is the metric value for all types. Plausibility guards prevent
-     * garbage samples (HR 40–200, SpO2 70–100, stress 0–100, HRV 20–200).
+     * Decode group-1 real-time vital result replies. Routed on the INBOUND result opcodes
+     * (`CMD_RESULT_*`), which are distinct from the outbound enable-timing commands. Confirmed
+     * against the vendor dispatcher `g1/a.java` (lines 664–712) and its per-vital parsers:
+     *   cmd 9  → HR    `e1/f.b`  : byte2int(payload[0])                     — guard 40..200
+     *   cmd 10 → HRV   `g1/a`    : byte2int(payload[0]) (live path)         — guard 20..200
+     *   cmd 11 → SpO2  `e1/d.b`  : byte2int(payload[0])                     — guard 70..100
+     *   cmd 14 → stress`g1/a`    : byte2int(payload[0])                     — guard 0..100
+     *   cmd 32 → temp  `e1/m.a`  : (payload[1]<<8 | payload[0]) / 10.0 °C   — guard 28.0..50.0
      */
     private fun decodeVitalResult(cmd: Int, payload: ByteArray, now: Instant): List<RingDecodedEvent> {
-        if (payload.isEmpty()) return listOf(RingDecodedEvent.CommandAck(commandId = ((CRPCommands.GROUP_DEVICE shl 4) or (cmd and 0x0F)).toUByte()))
+        fun ack() = listOf(RingDecodedEvent.CommandAck(commandId = ((CRPCommands.GROUP_DEVICE shl 4) or (cmd and 0x0F)).toUByte()))
+        if (payload.isEmpty()) return ack()
         val value = payload[0].toInt() and 0xFF
 
         return when (cmd) {
-            CRPCommands.CMD_MEASURE_HR -> {
-                // HR from `e1/f.b()`: byte2int(payload[0]).
+            CRPCommands.CMD_RESULT_HR ->
                 if (value in 40..200) listOf(RingDecodedEvent.HeartRateSample(bpm = value, _timestamp = now))
                 else emptyList()
-            }
-            CRPCommands.CMD_ENABLE_TIMING_HRV -> {
-                // HRV from `e1/g.d()`: twoBytes2int(payload[1], payload[0]), but vendor's
-                // onHrv() callback receives byte2int(payload[0]) for the live measurement path.
-                // We accept either layout: single-byte if payload is 1 byte, two-byte otherwise.
-                val hrvValue = if (payload.size >= 2) (
-                    (payload[0].toInt() and 0xFF) or ((payload[1].toInt() and 0xFF) shl 8)
-                ) else value
-                if (hrvValue in 20..200) listOf(RingDecodedEvent.HrvSample(value = hrvValue, _timestamp = now))
+            CRPCommands.CMD_RESULT_HRV ->
+                if (value in 20..200) listOf(RingDecodedEvent.HrvSample(value = value, _timestamp = now))
                 else emptyList()
-            }
-            CRPCommands.CMD_ENABLE_TIMING_SPO2 -> {
-                // SpO2 from `e1/d.b()`: byte2int(payload[0]).
+            CRPCommands.CMD_RESULT_SPO2 ->
                 if (value in 70..100) listOf(RingDecodedEvent.Spo2Result(value = value, _timestamp = now))
                 else emptyList()
-            }
-            CRPCommands.CMD_ENABLE_TIMING_STRESS -> {
-                // Stress/physical strength from `e1/h.c()`: byte2int(payload[0]).
+            CRPCommands.CMD_RESULT_STRESS ->
                 if (value in 0..100) listOf(RingDecodedEvent.StressSample(value = value, _timestamp = now))
                 else emptyList()
+            CRPCommands.CMD_RESULT_TEMP -> {
+                // Vendor `e1/m.a(payload[1], payload[0])`: twoBytes2int/10, valid 28.0..50.0 °C.
+                if (payload.size < 2) return emptyList()
+                val celsius = (((payload[1].toInt() and 0xFF) shl 8) or (payload[0].toInt() and 0xFF)) / 10.0
+                if (celsius in 28.0..50.0) listOf(RingDecodedEvent.TemperatureSample(celsius = celsius, _timestamp = now))
+                else emptyList()
             }
-            CRPCommands.CMD_ENABLE_TIMING_TEMP -> {
-                // Temperature: vendor uses onMeasureComplete with payload. Layout unconfirmed.
-                // Emit as temperature_sample with raw byte as placeholder until verified.
-                listOf(RingDecodedEvent.TemperatureSample(celsius = value.toDouble(), _timestamp = now))
-            }
-            else -> {
-                // Acknowledgment for enable/disable commands.
-                listOf(RingDecodedEvent.CommandAck(commandId = ((CRPCommands.GROUP_DEVICE shl 4) or (cmd and 0x0F)).toUByte()))
-            }
+            else -> ack() // enable/disable acknowledgments and other group-1 replies
         }
     }
 

--- a/app/src/main/java/com/pulseloop/ring/CRPDecoder.kt
+++ b/app/src/main/java/com/pulseloop/ring/CRPDecoder.kt
@@ -77,15 +77,50 @@ object CRPDecoder {
         return listOf(RingDecodedEvent.HeartRateSample(bpm = bpm, _timestamp = now))
     }
 
-    /** Framed `fdd3` reply: `FD DA 10 <len> <group> <cmd> <payload>`. v1 acknowledges recognised
-     *  command echoes; richer metric replies (HR/SpO2 results, history) are decoded as more
-     *  layouts are confirmed against the decompile/hardware. */
+    /** Framed `fdd3` reply: `FD DA 10 <len> <group> <cmd> <payload>`. Decodes vital readings
+     *  based on group/cmd. Unconfirmed layouts are logged for debugging. */
     private fun decodeFramedReply(frame: ByteArray, now: Instant): List<RingDecodedEvent> {
         if (frame.size < CRPProtocol.HEADER_SIZE) return emptyList()
         val group = frame[4].toInt() and 0xFF
         val cmd = frame[5].toInt() and 0xFF
-        // Only the command echo is confirmed for the v1 command set; treat as an ack so the
-        // raw-notify/debug feed still records it without inventing a metric value.
+        val payload = if (frame.size > CRPProtocol.HEADER_SIZE) frame.copyOfRange(CRPProtocol.HEADER_SIZE, frame.size) else ByteArray(0)
+
+        // Group 1: timing/enable responses (acknowledgments).
+        if (group == CRPCommands.GROUP_DEVICE) {
+            return listOf(RingDecodedEvent.CommandAck(commandId = ((group shl 4) or (cmd and 0x0F)).toUByte()))
+        }
+
+        // Group 2: history query responses.
+        if (group == CRPCommands.GROUP_HISTORY) {
+            return decodeHistoryResponse(group, cmd, payload, now)
+        }
+
+        // Group 7: device info responses.
+        if (group == CRPCommands.GROUP_DEVICE_INFO) {
+            return decodeDeviceInfoResponse(group, cmd, payload, now)
+        }
+
+        // Unknown group/cmd — log and ack.
+        return listOf(RingDecodedEvent.CommandAck(commandId = ((group shl 4) or (cmd and 0x0F)).toUByte()))
+    }
+
+    private fun decodeHistoryResponse(group: Int, cmd: Int, payload: ByteArray, now: Instant): List<RingDecodedEvent> {
+        // TODO: Decode based on cmd:
+        //   CMD_QUERY_HISTORY_HR (4) → heart rate samples
+        //   CMD_QUERY_HISTORY_STRESS (5) → stress samples
+        //   CMD_QUERY_HISTORY_SLEEP (14) → sleep timeline
+        //   CMD_QUERY_HISTORY_TEMP (48) → temperature samples
+        //   CMD_QUERY_HISTORY_HRV (6) → HRV samples
+        //   CMD_QUERY_HISTORY_SPO2 (7) → SpO2 samples
+        // For now, log the raw payload and return an ack.
+        return listOf(RingDecodedEvent.CommandAck(commandId = ((group shl 4) or (cmd and 0x0F)).toUByte()))
+    }
+
+    private fun decodeDeviceInfoResponse(group: Int, cmd: Int, payload: ByteArray, now: Instant): List<RingDecodedEvent> {
+        // TODO: Decode based on cmd:
+        //   CMD_QUERY_DEVICE_INFO (0) → device info
+        //   CMD_QUERY_FIRMWARE_VERSION (1) → firmware version
+        //   CMD_QUERY_DEVICE_SN (13) → device serial number
         return listOf(RingDecodedEvent.CommandAck(commandId = ((group shl 4) or (cmd and 0x0F)).toUByte()))
     }
 

--- a/app/src/main/java/com/pulseloop/ring/CRPDecoder.kt
+++ b/app/src/main/java/com/pulseloop/ring/CRPDecoder.kt
@@ -37,12 +37,19 @@ class CRPFrameAssembler {
  * `from` UUID [CRPDriver.ingest] passes through), matching the vendor's `g1/a.a(characteristic)`
  * dispatch:
  *   - `fdd1` → raw current-steps triples (no CRP header)
- *   - `2a37` → standard HR-measurement stream
  *   - `fdd3` → framed `FD DA …` command replies (already reassembled by [CRPFrameAssembler])
  *
- * Unverified-against-hardware layouts are decoded conservatively: anything whose byte layout isn't
- * confirmed from the decompile is emitted as [RingDecodedEvent.CommandAck]/[Unknown] rather than
- * fabricating a metric value. Extend [decodeFramedReply] as more command replies are confirmed.
+ * NOTE: This ring does NOT use the standard `2a37` HR characteristic — all vital results come
+ * back as framed replies on `fdd3` with group/cmd routing. The `2a37` path is dead code for CRP
+ * rings (removed during port).
+ *
+ * Group-1 replies (`g1/a.java` lines 664–712) carry real-time vital results:
+ *   cmd 9  → HR (payload[0] = bpm, per `e1/f.b()`)
+ *   cmd 10 → HRV (payload[0] = ms)
+ *   cmd 11 → SpO2 (payload[0] = percent)
+ *   cmd 14 → stress (payload[0] = 0..100)
+ *   cmd 32 → temperature (payload[0..] = raw)
+ *   Other cmd values → command acknowledgment.
  */
 object CRPDecoder {
 
@@ -50,7 +57,6 @@ object CRPDecoder {
         val src = from.lowercase()
         return when {
             src.contains("fdd1") -> decodeCurrentSteps(data, now)
-            src.contains("2a37") -> decodeHeartRateMeasure(data, now)
             CRPProtocol.isFrameStart(data) -> decodeFramedReply(data, now)
             else -> emptyList()
         }
@@ -66,62 +72,88 @@ object CRPDecoder {
         return listOf(RingDecodedEvent.ActivityUpdate(now, steps, distance, calories))
     }
 
-    /** Standard HR characteristic (`2a37`). From `g1/a.B`: bpm at byte[1], validated by the
-     *  `0x0400` marker at bytes[2..3] (big-endian: byte[3] high). */
-    private fun decodeHeartRateMeasure(data: ByteArray, now: Instant): List<RingDecodedEvent> {
-        if (data.size < 2) return emptyList()
-        val bpm = data[1].toInt() and 0xFF
-        val markerOk = data.size < 4 ||
-            (((data[3].toInt() and 0xFF) shl 8) or (data[2].toInt() and 0xFF)) == 0x0400
-        if (!markerOk || bpm <= 0) return emptyList()
-        return listOf(RingDecodedEvent.HeartRateSample(bpm = bpm, _timestamp = now))
-    }
-
-    /** Framed `fdd3` reply: `FD DA 10 <len> <group> <cmd> <payload>`. Decodes vital readings
-     *  based on group/cmd. Unconfirmed layouts are logged for debugging. */
+    /**
+     * Framed `fdd3` reply: `FD DA 10 <len> <group> <cmd> <payload>`.
+     * Real-time vital results come on group 1; history queries on group 7; device info on group 7.
+     */
     private fun decodeFramedReply(frame: ByteArray, now: Instant): List<RingDecodedEvent> {
         if (frame.size < CRPProtocol.HEADER_SIZE) return emptyList()
         val group = frame[4].toInt() and 0xFF
         val cmd = frame[5].toInt() and 0xFF
         val payload = if (frame.size > CRPProtocol.HEADER_SIZE) frame.copyOfRange(CRPProtocol.HEADER_SIZE, frame.size) else ByteArray(0)
 
-        // Group 1: timing/enable responses (acknowledgments).
+        // Group 1: real-time vital results (decompiled `g1/a.java` lines 664–712).
         if (group == CRPCommands.GROUP_DEVICE) {
-            return listOf(RingDecodedEvent.CommandAck(commandId = ((group shl 4) or (cmd and 0x0F)).toUByte()))
+            return decodeVitalResult(cmd, payload, now)
         }
 
-        // Group 2: history query responses.
-        if (group == CRPCommands.GROUP_HISTORY) {
-            return decodeHistoryResponse(group, cmd, payload, now)
-        }
-
-        // Group 7: device info responses.
+        // Group 7: history queries + device info (decompiled `b1/e0` + `b1/r`).
         if (group == CRPCommands.GROUP_DEVICE_INFO) {
-            return decodeDeviceInfoResponse(group, cmd, payload, now)
+            return decodeHistoryOrDeviceInfoResponse(cmd, payload, now)
         }
 
-        // Unknown group/cmd — log and ack.
+        // Unknown group/cmd — ack.
         return listOf(RingDecodedEvent.CommandAck(commandId = ((group shl 4) or (cmd and 0x0F)).toUByte()))
     }
 
-    private fun decodeHistoryResponse(group: Int, cmd: Int, payload: ByteArray, now: Instant): List<RingDecodedEvent> {
-        // TODO: Decode based on cmd:
-        //   CMD_QUERY_HISTORY_HR (4) → heart rate samples
-        //   CMD_QUERY_HISTORY_STRESS (5) → stress samples
-        //   CMD_QUERY_HISTORY_SLEEP (14) → sleep timeline
-        //   CMD_QUERY_HISTORY_TEMP (48) → temperature samples
-        //   CMD_QUERY_HISTORY_HRV (6) → HRV samples
-        //   CMD_QUERY_HISTORY_SPO2 (7) → SpO2 samples
-        // For now, log the raw payload and return an ack.
-        return listOf(RingDecodedEvent.CommandAck(commandId = ((group shl 4) or (cmd and 0x0F)).toUByte()))
+    /**
+     * Decode group-1 vital result replies. Confirmed against `g1/a.java` and `e1/f.java` (HR),
+     * `e1/g.java` (HRV), `e1/d.java` (SpO2), `e1/h.java` (stress/physical strength), and
+     * the vendor's `onMeasureComplete` flow for temperature (cmd 32).
+     *
+     * Layout: `payload[0]` is the metric value for all types. Plausibility guards prevent
+     * garbage samples (HR 40–200, SpO2 70–100, stress 0–100, HRV 20–200).
+     */
+    private fun decodeVitalResult(cmd: Int, payload: ByteArray, now: Instant): List<RingDecodedEvent> {
+        if (payload.isEmpty()) return listOf(RingDecodedEvent.CommandAck(commandId = ((CRPCommands.GROUP_DEVICE shl 4) or (cmd and 0x0F)).toUByte()))
+        val value = payload[0].toInt() and 0xFF
+
+        return when (cmd) {
+            CRPCommands.CMD_MEASURE_HR -> {
+                // HR from `e1/f.b()`: byte2int(payload[0]).
+                if (value in 40..200) listOf(RingDecodedEvent.HeartRateSample(bpm = value, _timestamp = now))
+                else emptyList()
+            }
+            CRPCommands.CMD_ENABLE_TIMING_HRV -> {
+                // HRV from `e1/g.d()`: twoBytes2int(payload[1], payload[0]), but vendor's
+                // onHrv() callback receives byte2int(payload[0]) for the live measurement path.
+                // We accept either layout: single-byte if payload is 1 byte, two-byte otherwise.
+                val hrvValue = if (payload.size >= 2) (
+                    (payload[0].toInt() and 0xFF) or ((payload[1].toInt() and 0xFF) shl 8)
+                ) else value
+                if (hrvValue in 20..200) listOf(RingDecodedEvent.HrvSample(value = hrvValue, _timestamp = now))
+                else emptyList()
+            }
+            CRPCommands.CMD_ENABLE_TIMING_SPO2 -> {
+                // SpO2 from `e1/d.b()`: byte2int(payload[0]).
+                if (value in 70..100) listOf(RingDecodedEvent.Spo2Result(value = value, _timestamp = now))
+                else emptyList()
+            }
+            CRPCommands.CMD_ENABLE_TIMING_STRESS -> {
+                // Stress/physical strength from `e1/h.c()`: byte2int(payload[0]).
+                if (value in 0..100) listOf(RingDecodedEvent.StressSample(value = value, _timestamp = now))
+                else emptyList()
+            }
+            CRPCommands.CMD_ENABLE_TIMING_TEMP -> {
+                // Temperature: vendor uses onMeasureComplete with payload. Layout unconfirmed.
+                // Emit as temperature_sample with raw byte as placeholder until verified.
+                listOf(RingDecodedEvent.TemperatureSample(celsius = value.toDouble(), _timestamp = now))
+            }
+            else -> {
+                // Acknowledgment for enable/disable commands.
+                listOf(RingDecodedEvent.CommandAck(commandId = ((CRPCommands.GROUP_DEVICE shl 4) or (cmd and 0x0F)).toUByte()))
+            }
+        }
     }
 
-    private fun decodeDeviceInfoResponse(group: Int, cmd: Int, payload: ByteArray, now: Instant): List<RingDecodedEvent> {
-        // TODO: Decode based on cmd:
-        //   CMD_QUERY_DEVICE_INFO (0) → device info
-        //   CMD_QUERY_FIRMWARE_VERSION (1) → firmware version
-        //   CMD_QUERY_DEVICE_SN (13) → device serial number
-        return listOf(RingDecodedEvent.CommandAck(commandId = ((group shl 4) or (cmd and 0x0F)).toUByte()))
+    /**
+     * Decode group-7 responses: history queries (cmd 4–7, 14, 48) and device info (cmd 0, 1, 13).
+     * History layouts are unconfirmed against hardware — emit as CommandAck so the raw-packet feed
+     * records them without inventing metric values. Extend [decodeHistoryOrDeviceInfoResponse]
+     * as more layouts are confirmed.
+     */
+    private fun decodeHistoryOrDeviceInfoResponse(cmd: Int, payload: ByteArray, now: Instant): List<RingDecodedEvent> {
+        return listOf(RingDecodedEvent.CommandAck(commandId = ((CRPCommands.GROUP_DEVICE_INFO shl 4) or (cmd and 0x0F)).toUByte()))
     }
 
     /** Little-endian unsigned 3-byte int at [offset]. */

--- a/app/src/main/java/com/pulseloop/ring/CRPProtocol.kt
+++ b/app/src/main/java/com/pulseloop/ring/CRPProtocol.kt
@@ -54,6 +54,33 @@ object CRPCommands {
     const val CMD_MEASURE_HR = 9        // b1/t.d: [enable] — start(1)/stop(0) continuous HR
     const val CMD_MEASURE_SPO2 = 11     // b1/h.d: [enable] — start(1)/stop(0) SpO2
 
+    // Group 1 — timing/enable controls (decompiled b1 package).
+    const val CMD_ENABLE_TIMING_HR = 7        // b1/t.a: group1/cmd7
+    const val CMD_DISABLE_TIMING_HR = 8       // b1/t.b: group1/cmd8
+    const val CMD_ENABLE_TIMING_HRV = 9       // b1/u.a: group1/cmd9
+    const val CMD_DISABLE_TIMING_HRV = 10     // b1/u.b: group1/cmd10
+    const val CMD_ENABLE_TIMING_SPO2 = 11     // b1/h.a: group1/cmd11
+    const val CMD_DISABLE_TIMING_SPO2 = 12    // b1/h.b: group1/cmd12
+    const val CMD_ENABLE_TIMING_STRESS = 13   // b1/h0.a: group1/cmd13
+    const val CMD_DISABLE_TIMING_STRESS = 14  // b1/h0.b: group1/cmd14
+    const val CMD_ENABLE_TIMING_TEMP = 15     // b1/i0.a: group1/cmd15
+    const val CMD_DISABLE_TIMING_TEMP = 16    // b1/i0.b: group1/cmd16
+
+    // Group 2 — history queries (decompiled b1/e0).
+    const val GROUP_HISTORY = 2
+    const val CMD_QUERY_HISTORY_HR = 4        // b1/e0.a: group2/cmd4
+    const val CMD_QUERY_HISTORY_STRESS = 5    // b1/e0.b: group2/cmd5
+    const val CMD_QUERY_HISTORY_SLEEP = 14    // b1/e0.c: group2/cmd14 (CRPHistoryDay)
+    const val CMD_QUERY_HISTORY_TEMP = 48     // b1/e0.d: group2/cmd48
+    const val CMD_QUERY_HISTORY_HRV = 6       // b1/e0.e: group2/cmd6
+    const val CMD_QUERY_HISTORY_SPO2 = 7      // b1/e0.f: group2/cmd7
+
+    // Group 7 — device info / support.
+    const val GROUP_DEVICE_INFO = 7
+    const val CMD_QUERY_DEVICE_INFO = 0       // b1/r.a: group7/cmd0
+    const val CMD_QUERY_FIRMWARE_VERSION = 1  // b1/r.b: group7/cmd1
+    const val CMD_QUERY_DEVICE_SN = 13        // b1/r.c: group7/cmd13
+
     // Group 3 — power control.
     const val GROUP_POWER = 3
     const val CMD_FACTORY_RESET = 0     // b1/l.v: q.b(3,0)
@@ -140,4 +167,69 @@ object CRPProtocol {
         frame(CRPCommands.GROUP_ACTION, CRPCommands.CMD_FIND_DEVICE, byteArrayOf(if (enable) 1 else 0))
 
     fun factoryReset(): ByteArray = frame(CRPCommands.GROUP_POWER, CRPCommands.CMD_FACTORY_RESET)
+
+    // ---- Timing/enable commands (group 1) ----
+    // The vendor app always sends an interval byte when enabling vital timing. We default to 5
+    // minutes (common for Colmi/Moyoung rings) — verify against hardware and adjust if needed.
+
+    fun enableTimingHeartRate(intervalMinutes: Int = 5): ByteArray =
+        frame(CRPCommands.GROUP_DEVICE, CRPCommands.CMD_ENABLE_TIMING_HR, byteArrayOf(intervalMinutes.toByte()))
+
+    fun disableTimingHeartRate(): ByteArray =
+        frame(CRPCommands.GROUP_DEVICE, CRPCommands.CMD_DISABLE_TIMING_HR)
+
+    fun enableTimingHRV(intervalMinutes: Int = 5): ByteArray =
+        frame(CRPCommands.GROUP_DEVICE, CRPCommands.CMD_ENABLE_TIMING_HRV, byteArrayOf(intervalMinutes.toByte()))
+
+    fun disableTimingHRV(): ByteArray =
+        frame(CRPCommands.GROUP_DEVICE, CRPCommands.CMD_DISABLE_TIMING_HRV)
+
+    fun enableTimingSpO2(intervalMinutes: Int = 5): ByteArray =
+        frame(CRPCommands.GROUP_DEVICE, CRPCommands.CMD_ENABLE_TIMING_SPO2, byteArrayOf(intervalMinutes.toByte()))
+
+    fun disableTimingSpO2(): ByteArray =
+        frame(CRPCommands.GROUP_DEVICE, CRPCommands.CMD_DISABLE_TIMING_SPO2)
+
+    fun enableTimingStress(intervalMinutes: Int = 5): ByteArray =
+        frame(CRPCommands.GROUP_DEVICE, CRPCommands.CMD_ENABLE_TIMING_STRESS, byteArrayOf(intervalMinutes.toByte()))
+
+    fun disableTimingStress(): ByteArray =
+        frame(CRPCommands.GROUP_DEVICE, CRPCommands.CMD_DISABLE_TIMING_STRESS)
+
+    fun enableTimingTemp(): ByteArray =
+        frame(CRPCommands.GROUP_DEVICE, CRPCommands.CMD_ENABLE_TIMING_TEMP)
+
+    fun disableTimingTemp(): ByteArray =
+        frame(CRPCommands.GROUP_DEVICE, CRPCommands.CMD_DISABLE_TIMING_TEMP)
+
+    // ---- History query commands (group 2) ----
+
+    fun queryHistoryHeartRate(): ByteArray =
+        frame(CRPCommands.GROUP_HISTORY, CRPCommands.CMD_QUERY_HISTORY_HR)
+
+    fun queryHistoryStress(): ByteArray =
+        frame(CRPCommands.GROUP_HISTORY, CRPCommands.CMD_QUERY_HISTORY_STRESS)
+
+    fun queryHistorySleep(daysAgo: Int = 0): ByteArray =
+        frame(CRPCommands.GROUP_HISTORY, CRPCommands.CMD_QUERY_HISTORY_SLEEP, byteArrayOf(daysAgo.toByte()))
+
+    fun queryHistoryTemp(): ByteArray =
+        frame(CRPCommands.GROUP_HISTORY, CRPCommands.CMD_QUERY_HISTORY_TEMP)
+
+    fun queryHistoryHRV(): ByteArray =
+        frame(CRPCommands.GROUP_HISTORY, CRPCommands.CMD_QUERY_HISTORY_HRV)
+
+    fun queryHistorySpO2(): ByteArray =
+        frame(CRPCommands.GROUP_HISTORY, CRPCommands.CMD_QUERY_HISTORY_SPO2)
+
+    // ---- Device info queries (group 7) ----
+
+    fun queryDeviceInfo(): ByteArray =
+        frame(CRPCommands.GROUP_DEVICE_INFO, CRPCommands.CMD_QUERY_DEVICE_INFO)
+
+    fun queryFirmwareVersion(): ByteArray =
+        frame(CRPCommands.GROUP_DEVICE_INFO, CRPCommands.CMD_QUERY_FIRMWARE_VERSION)
+
+    fun queryDeviceSN(): ByteArray =
+        frame(CRPCommands.GROUP_DEVICE_INFO, CRPCommands.CMD_QUERY_DEVICE_SN)
 }

--- a/app/src/main/java/com/pulseloop/ring/CRPProtocol.kt
+++ b/app/src/main/java/com/pulseloop/ring/CRPProtocol.kt
@@ -51,8 +51,25 @@ object CRPCommands {
     const val GROUP_DEVICE = 1
     const val CMD_SET_USER_INFO = 0     // b1/k.a: [height, weight, age, gender, strideLen]
     const val CMD_SET_TIME = 1          // b1/e.b: [epochSecondsLE(4), tzByte]
-    const val CMD_MEASURE_HR = 9        // b1/t.d: [enable] — start(1)/stop(0) continuous HR
-    const val CMD_MEASURE_SPO2 = 11     // b1/h.d: [enable] — start(1)/stop(0) SpO2
+    // Group 1 — spot (manual) measurement toggles (OUTBOUND). Each is `[enable]` — start(1)/stop(0)
+    // a one-shot on-demand measurement. Source: the vendor SDK's `startMeasureX`/`stopMeasureX`
+    // (`d1/b.java`) → the `b1` builders. The ring reports the reading back on the SAME cmd byte
+    // (see CMD_RESULT_* below), which is why these opcodes double as the result opcodes.
+    const val CMD_MEASURE_HR = 9        // b1/t.d:  q.c(1,9,  [enable])
+    const val CMD_MEASURE_HRV = 10      // b1/u.d:  q.c(1,10, [enable])
+    const val CMD_MEASURE_SPO2 = 11     // b1/h.d:  q.c(1,11, [enable])
+    const val CMD_MEASURE_STRESS = 14   // b1/h0.d: q.c(1,14, [enable])
+    const val CMD_MEASURE_TEMP = 32     // b1/i0.d: q.c(1,32, [enable])
+
+    // Group 1 — real-time result reply opcodes (INBOUND). The cmd byte the ring puts on the framed
+    // `fdd3` channel when it reports a live reading — identical to the measure opcode above (the
+    // measurement echoes back on its own cmd). Source: vendor dispatcher `g1/a.java` lines 664–712
+    // (case group==1): 9→onHeartRate, 10→onHrv, 11→onBloodOxygen, 14→onStressChange, 32→onMeasureComplete(temp).
+    const val CMD_RESULT_HR = CMD_MEASURE_HR         // g1/a: onHeartRate(e1/f.b → payload[0])
+    const val CMD_RESULT_HRV = CMD_MEASURE_HRV       // g1/a: onHrv(byte2int(payload[0]))
+    const val CMD_RESULT_SPO2 = CMD_MEASURE_SPO2     // g1/a: onBloodOxygen(e1/d.b → payload[0])
+    const val CMD_RESULT_STRESS = CMD_MEASURE_STRESS // g1/a: onStressChange(byte2int(payload[0]))
+    const val CMD_RESULT_TEMP = CMD_MEASURE_TEMP     // g1/a: onMeasureComplete(e1/m.a → (payload[1]<<8|payload[0])/10)
 
     // Group 1 — timing/enable controls (decompiled b1 package).
     // Disable: HR/HRV/SpO2/Stress use enable with interval=0. Temp uses a separate cmd.
@@ -60,11 +77,12 @@ object CRPCommands {
     const val CMD_ENABLE_TIMING_HRV = 7       // b1/u.c: q.c(1,7, [interval])
     const val CMD_ENABLE_TIMING_SPO2 = 8      // b1/h.c: q.c(1,8, [interval])
     const val CMD_ENABLE_TIMING_STRESS = 39   // b1/h0.c: q.c(1,39, [interval])
-    const val CMD_ENABLE_TIMING_TEMP = 13     // b1/i0.c: q.c(1,13, [true])
-    const val CMD_DISABLE_TIMING_TEMP = 32    // b1/i0.d: q.c(1,32, [false]) — vendor uses this for temp disable
+    const val CMD_ENABLE_TIMING_TEMP = 13     // b1/i0.c: q.c(1,13, [enable]) — all-day temp timing on/off
+    // NOTE: temp's spot-measure toggle is a DIFFERENT opcode (cmd 32, b1/i0.d) — see CMD_MEASURE_TEMP.
 
     // Group 7 — history queries + device info (decompiled b1/e0 + b1/r).
-    // NOTE: History queries are group 7, NOT group 2 (the b1/e0 builders use q.b(7,…) and q.c(7,…)).
+    // NOTE: most history queries are group 7 (b1/e0 builders use q.b(7,…)/q.c(7,…)), but sleep
+    // and temp are the exception — they live on group 2 (see GROUP_HISTORY below).
     const val GROUP_DEVICE_INFO = 7
     const val CMD_QUERY_DEVICE_INFO = 0       // b1/r.a: q.b(7,0)
     const val CMD_QUERY_FIRMWARE_VERSION = 1  // b1/r.b: q.b(7,1)
@@ -73,8 +91,11 @@ object CRPCommands {
     const val CMD_QUERY_HISTORY_STRESS = 5    // b1/e0.b: q.c(7,5, [interval])
     const val CMD_QUERY_HISTORY_HRV = 6       // b1/e0.e: q.c(7,6, [interval])
     const val CMD_QUERY_HISTORY_SPO2 = 7      // b1/e0.f: q.b(7,7)
+
+    // Group 2 — the two history queries that live outside group 7 (decompiled b1/e0).
+    const val GROUP_HISTORY = 2
     const val CMD_QUERY_HISTORY_SLEEP = 14    // b1/e0.c: q.c(2,14, [CRPHistoryDay])
-    const val CMD_QUERY_HISTORY_TEMP = 48     // b1/e0.d: q.b(7,48)
+    const val CMD_QUERY_HISTORY_TEMP = 48     // b1/e0.d: q.b(2,48)
 
     // Group 3 — power control.
     const val GROUP_POWER = 3
@@ -152,11 +173,25 @@ object CRPProtocol {
         return frame(CRPCommands.GROUP_DEVICE, CRPCommands.CMD_SET_USER_INFO, payload)
     }
 
+    // ---- Spot (manual) measurement toggles ----
+    // start(true)/stop(false) an on-demand reading; the ring reports back on the same cmd byte,
+    // decoded by CRPDecoder.decodeVitalResult. Mirrors the vendor's startMeasureX/stopMeasureX
+    // (`d1/b.java` → `b1/t.d`,`u.d`,`h.d`,`h0.d`,`i0.d`).
+
     fun measureHeartRate(enable: Boolean): ByteArray =
         frame(CRPCommands.GROUP_DEVICE, CRPCommands.CMD_MEASURE_HR, byteArrayOf(if (enable) 1 else 0))
 
+    fun measureHRV(enable: Boolean): ByteArray =
+        frame(CRPCommands.GROUP_DEVICE, CRPCommands.CMD_MEASURE_HRV, byteArrayOf(if (enable) 1 else 0))
+
     fun measureSpO2(enable: Boolean): ByteArray =
         frame(CRPCommands.GROUP_DEVICE, CRPCommands.CMD_MEASURE_SPO2, byteArrayOf(if (enable) 1 else 0))
+
+    fun measureStress(enable: Boolean): ByteArray =
+        frame(CRPCommands.GROUP_DEVICE, CRPCommands.CMD_MEASURE_STRESS, byteArrayOf(if (enable) 1 else 0))
+
+    fun measureTemp(enable: Boolean): ByteArray =
+        frame(CRPCommands.GROUP_DEVICE, CRPCommands.CMD_MEASURE_TEMP, byteArrayOf(if (enable) 1 else 0))
 
     fun findDevice(enable: Boolean): ByteArray =
         frame(CRPCommands.GROUP_ACTION, CRPCommands.CMD_FIND_DEVICE, byteArrayOf(if (enable) 1 else 0))
@@ -193,18 +228,19 @@ object CRPProtocol {
         frame(CRPCommands.GROUP_DEVICE, CRPCommands.CMD_ENABLE_TIMING_STRESS, byteArrayOf(0))
 
     fun enableTimingTemp(): ByteArray =
-        frame(CRPCommands.GROUP_DEVICE, CRPCommands.CMD_ENABLE_TIMING_TEMP)
+        frame(CRPCommands.GROUP_DEVICE, CRPCommands.CMD_ENABLE_TIMING_TEMP, byteArrayOf(1))
 
     fun disableTimingTemp(): ByteArray =
-        frame(CRPCommands.GROUP_DEVICE, CRPCommands.CMD_DISABLE_TIMING_TEMP)
+        frame(CRPCommands.GROUP_DEVICE, CRPCommands.CMD_ENABLE_TIMING_TEMP, byteArrayOf(0))
 
-    // ---- History query commands (group 2) ----
+    // ---- History query commands ----
+    // Most vitals are group 7 (b1/e0.a/b/e/f); sleep and temp are group 2 (b1/e0.c/d).
 
     fun queryHistoryHeartRate(): ByteArray =
-        frame(CRPCommands.GROUP_HISTORY, CRPCommands.CMD_QUERY_HISTORY_HR)
+        frame(CRPCommands.GROUP_DEVICE_INFO, CRPCommands.CMD_QUERY_HISTORY_HR)
 
     fun queryHistoryStress(): ByteArray =
-        frame(CRPCommands.GROUP_HISTORY, CRPCommands.CMD_QUERY_HISTORY_STRESS)
+        frame(CRPCommands.GROUP_DEVICE_INFO, CRPCommands.CMD_QUERY_HISTORY_STRESS)
 
     fun queryHistorySleep(daysAgo: Int = 0): ByteArray =
         frame(CRPCommands.GROUP_HISTORY, CRPCommands.CMD_QUERY_HISTORY_SLEEP, byteArrayOf(daysAgo.toByte()))
@@ -213,10 +249,10 @@ object CRPProtocol {
         frame(CRPCommands.GROUP_HISTORY, CRPCommands.CMD_QUERY_HISTORY_TEMP)
 
     fun queryHistoryHRV(): ByteArray =
-        frame(CRPCommands.GROUP_HISTORY, CRPCommands.CMD_QUERY_HISTORY_HRV)
+        frame(CRPCommands.GROUP_DEVICE_INFO, CRPCommands.CMD_QUERY_HISTORY_HRV)
 
     fun queryHistorySpO2(): ByteArray =
-        frame(CRPCommands.GROUP_HISTORY, CRPCommands.CMD_QUERY_HISTORY_SPO2)
+        frame(CRPCommands.GROUP_DEVICE_INFO, CRPCommands.CMD_QUERY_HISTORY_SPO2)
 
     // ---- Device info queries (group 7) ----
 

--- a/app/src/main/java/com/pulseloop/ring/CRPProtocol.kt
+++ b/app/src/main/java/com/pulseloop/ring/CRPProtocol.kt
@@ -55,31 +55,26 @@ object CRPCommands {
     const val CMD_MEASURE_SPO2 = 11     // b1/h.d: [enable] — start(1)/stop(0) SpO2
 
     // Group 1 — timing/enable controls (decompiled b1 package).
-    const val CMD_ENABLE_TIMING_HR = 7        // b1/t.a: group1/cmd7
-    const val CMD_DISABLE_TIMING_HR = 8       // b1/t.b: group1/cmd8
-    const val CMD_ENABLE_TIMING_HRV = 9       // b1/u.a: group1/cmd9
-    const val CMD_DISABLE_TIMING_HRV = 10     // b1/u.b: group1/cmd10
-    const val CMD_ENABLE_TIMING_SPO2 = 11     // b1/h.a: group1/cmd11
-    const val CMD_DISABLE_TIMING_SPO2 = 12    // b1/h.b: group1/cmd12
-    const val CMD_ENABLE_TIMING_STRESS = 13   // b1/h0.a: group1/cmd13
-    const val CMD_DISABLE_TIMING_STRESS = 14  // b1/h0.b: group1/cmd14
-    const val CMD_ENABLE_TIMING_TEMP = 15     // b1/i0.a: group1/cmd15
-    const val CMD_DISABLE_TIMING_TEMP = 16    // b1/i0.b: group1/cmd16
+    // Disable: HR/HRV/SpO2/Stress use enable with interval=0. Temp uses a separate cmd.
+    const val CMD_ENABLE_TIMING_HR = 6        // b1/t.c: q.c(1,6, [interval])
+    const val CMD_ENABLE_TIMING_HRV = 7       // b1/u.c: q.c(1,7, [interval])
+    const val CMD_ENABLE_TIMING_SPO2 = 8      // b1/h.c: q.c(1,8, [interval])
+    const val CMD_ENABLE_TIMING_STRESS = 39   // b1/h0.c: q.c(1,39, [interval])
+    const val CMD_ENABLE_TIMING_TEMP = 13     // b1/i0.c: q.c(1,13, [true])
+    const val CMD_DISABLE_TIMING_TEMP = 32    // b1/i0.d: q.c(1,32, [false]) — vendor uses this for temp disable
 
-    // Group 2 — history queries (decompiled b1/e0).
-    const val GROUP_HISTORY = 2
-    const val CMD_QUERY_HISTORY_HR = 4        // b1/e0.a: group2/cmd4
-    const val CMD_QUERY_HISTORY_STRESS = 5    // b1/e0.b: group2/cmd5
-    const val CMD_QUERY_HISTORY_SLEEP = 14    // b1/e0.c: group2/cmd14 (CRPHistoryDay)
-    const val CMD_QUERY_HISTORY_TEMP = 48     // b1/e0.d: group2/cmd48
-    const val CMD_QUERY_HISTORY_HRV = 6       // b1/e0.e: group2/cmd6
-    const val CMD_QUERY_HISTORY_SPO2 = 7      // b1/e0.f: group2/cmd7
-
-    // Group 7 — device info / support.
+    // Group 7 — history queries + device info (decompiled b1/e0 + b1/r).
+    // NOTE: History queries are group 7, NOT group 2 (the b1/e0 builders use q.b(7,…) and q.c(7,…)).
     const val GROUP_DEVICE_INFO = 7
-    const val CMD_QUERY_DEVICE_INFO = 0       // b1/r.a: group7/cmd0
-    const val CMD_QUERY_FIRMWARE_VERSION = 1  // b1/r.b: group7/cmd1
-    const val CMD_QUERY_DEVICE_SN = 13        // b1/r.c: group7/cmd13
+    const val CMD_QUERY_DEVICE_INFO = 0       // b1/r.a: q.b(7,0)
+    const val CMD_QUERY_FIRMWARE_VERSION = 1  // b1/r.b: q.b(7,1)
+    const val CMD_QUERY_DEVICE_SN = 13        // b1/r.c: q.b(7,13)
+    const val CMD_QUERY_HISTORY_HR = 4        // b1/e0.a: q.b(7,4)
+    const val CMD_QUERY_HISTORY_STRESS = 5    // b1/e0.b: q.c(7,5, [interval])
+    const val CMD_QUERY_HISTORY_HRV = 6       // b1/e0.e: q.c(7,6, [interval])
+    const val CMD_QUERY_HISTORY_SPO2 = 7      // b1/e0.f: q.b(7,7)
+    const val CMD_QUERY_HISTORY_SLEEP = 14    // b1/e0.c: q.c(2,14, [CRPHistoryDay])
+    const val CMD_QUERY_HISTORY_TEMP = 48     // b1/e0.d: q.b(7,48)
 
     // Group 3 — power control.
     const val GROUP_POWER = 3
@@ -169,32 +164,33 @@ object CRPProtocol {
     fun factoryReset(): ByteArray = frame(CRPCommands.GROUP_POWER, CRPCommands.CMD_FACTORY_RESET)
 
     // ---- Timing/enable commands (group 1) ----
-    // The vendor app always sends an interval byte when enabling vital timing. We default to 5
-    // minutes (common for Colmi/Moyoung rings) — verify against hardware and adjust if needed.
+    // HR/HRV/SpO2/Stress disable by sending enable with interval=0 (per d1/b.java disable* methods).
+    // Temp disable uses a separate cmd (32) with [false] (per b1/i0.d and d1/b.java disableTimingTemp).
+    // The vendor app always sends an interval byte when enabling vital timing.
 
-    fun enableTimingHeartRate(intervalMinutes: Int = 5): ByteArray =
+    fun enableTimingHeartRate(intervalMinutes: Int): ByteArray =
         frame(CRPCommands.GROUP_DEVICE, CRPCommands.CMD_ENABLE_TIMING_HR, byteArrayOf(intervalMinutes.toByte()))
 
     fun disableTimingHeartRate(): ByteArray =
-        frame(CRPCommands.GROUP_DEVICE, CRPCommands.CMD_DISABLE_TIMING_HR)
+        frame(CRPCommands.GROUP_DEVICE, CRPCommands.CMD_ENABLE_TIMING_HR, byteArrayOf(0))
 
-    fun enableTimingHRV(intervalMinutes: Int = 5): ByteArray =
+    fun enableTimingHRV(intervalMinutes: Int): ByteArray =
         frame(CRPCommands.GROUP_DEVICE, CRPCommands.CMD_ENABLE_TIMING_HRV, byteArrayOf(intervalMinutes.toByte()))
 
     fun disableTimingHRV(): ByteArray =
-        frame(CRPCommands.GROUP_DEVICE, CRPCommands.CMD_DISABLE_TIMING_HRV)
+        frame(CRPCommands.GROUP_DEVICE, CRPCommands.CMD_ENABLE_TIMING_HRV, byteArrayOf(0))
 
-    fun enableTimingSpO2(intervalMinutes: Int = 5): ByteArray =
+    fun enableTimingSpO2(intervalMinutes: Int): ByteArray =
         frame(CRPCommands.GROUP_DEVICE, CRPCommands.CMD_ENABLE_TIMING_SPO2, byteArrayOf(intervalMinutes.toByte()))
 
     fun disableTimingSpO2(): ByteArray =
-        frame(CRPCommands.GROUP_DEVICE, CRPCommands.CMD_DISABLE_TIMING_SPO2)
+        frame(CRPCommands.GROUP_DEVICE, CRPCommands.CMD_ENABLE_TIMING_SPO2, byteArrayOf(0))
 
-    fun enableTimingStress(intervalMinutes: Int = 5): ByteArray =
+    fun enableTimingStress(intervalMinutes: Int): ByteArray =
         frame(CRPCommands.GROUP_DEVICE, CRPCommands.CMD_ENABLE_TIMING_STRESS, byteArrayOf(intervalMinutes.toByte()))
 
     fun disableTimingStress(): ByteArray =
-        frame(CRPCommands.GROUP_DEVICE, CRPCommands.CMD_DISABLE_TIMING_STRESS)
+        frame(CRPCommands.GROUP_DEVICE, CRPCommands.CMD_ENABLE_TIMING_STRESS, byteArrayOf(0))
 
     fun enableTimingTemp(): ByteArray =
         frame(CRPCommands.GROUP_DEVICE, CRPCommands.CMD_ENABLE_TIMING_TEMP)

--- a/app/src/main/java/com/pulseloop/ring/CRPSyncEngine.kt
+++ b/app/src/main/java/com/pulseloop/ring/CRPSyncEngine.kt
@@ -4,14 +4,13 @@ package com.pulseloop.ring
  * Per-connection orchestration for a CRP ("crrepa") ring. Ported in spirit from the Moyoung
  * "Da Rings" connect flow (`d1/b.java` + `b1` package builders): after the link is up the app sets the
  * clock and pushes user anthropometrics, then the ring streams current steps (`fdd1`) on its own
- * and answers measurement commands. There is no bulk history state machine in v1, so most of the
- * [RingSyncEngine] surface is left as the interface's no-op defaults.
+ * and answers measurement commands. The bulk-history state machine stays deferred for now.
  *
- * v1 scope: clock + user-info handshake, live/manual heart rate, find-device, factory reset.
- * Steps and battery arrive as autonomous pushes/reads (see [CRPDriver]) and need no command here.
- * Sleep / SpO2 / HRV / stress / temperature and history sync are deliberately deferred — their
- * reply layouts aren't yet confirmed against the decompile, and [CRPCoordinator] doesn't advertise
- * those capabilities, so nothing calls the corresponding methods.
+ * Scope: clock + user-info handshake, spot HR + SpO2 (Measure button), all-day vital timing
+ * enable/disable driven by [MeasurementSettings], find-device, factory reset. Steps and battery
+ * arrive as autonomous pushes/reads (see [CRPDriver]). HRV / stress / temperature are all-day
+ * metrics — their timing is enabled here and live results decode via [CRPDecoder], but pulling the
+ * stored day timeline (group-7/group-2 history queries) is still TODO pending a hardware capture.
  */
 class CRPSyncEngine(private val writer: RingCommandWriter?) : RingSyncEngine {
 
@@ -47,11 +46,13 @@ class CRPSyncEngine(private val writer: RingCommandWriter?) : RingSyncEngine {
         // engine-side state (no staged history pipeline to advance).
     }
 
-    // ---- Heart rate (standard 2a37 stream, started/stopped via the fdda command channel) ----
+    // ---- Spot (manual) measurements. Trigger via the fdda command channel; the ring replies on
+    // the same group-1/cmd, decoded by CRPDecoder.decodeVitalResult and persisted via the bridge.
+    // HR and SpO2 are the app's spot-measurable vitals (MANUAL_* capabilities); HRV/stress/temp are
+    // all-day metrics pulled through timing + history, not the Measure button. ----
     override fun startHeartRate() { send(CRPProtocol.measureHeartRate(true)) }
     override fun stopHeartRate() { send(CRPProtocol.measureHeartRate(false)) }
 
-    // ---- SpO2 (command verified; result parsing deferred, so capability isn't advertised) ----
     override fun startSpO2() { send(CRPProtocol.measureSpO2(true)) }
     override fun stopSpO2() { send(CRPProtocol.measureSpO2(false)) }
 

--- a/app/src/main/java/com/pulseloop/ring/CRPSyncEngine.kt
+++ b/app/src/main/java/com/pulseloop/ring/CRPSyncEngine.kt
@@ -17,11 +17,27 @@ class CRPSyncEngine(private val writer: RingCommandWriter?) : RingSyncEngine {
 
     private var profile: UserProfileValues? = null
 
+    /** User-chosen all-day measurement config. Applied in the connect handshake and updatable
+     *  live via [applyMeasurementSettings]. `null` ⇒ the user has never saved one, so the engine
+     *  skips the vital enable commands (the ring's own settings are the source of truth). */
+    private var measurementSettings: MeasurementSettings? = null
+
     override fun runStartup() {
         // Set the device clock first (matches the vendor's connect handshake), then user info so
         // the ring's step/calorie algorithm has real inputs.
         send(CRPProtocol.setTime())
         profile?.let { send(userInfoFrame(it)) }
+        // Enable vital monitoring only when the user has configured it (mirrors the vendor app's
+        // connect flow). Uses the user's polling interval for all vital types — the CRP protocol
+        // takes a single interval byte per enable command, and MeasurementSettings only exposes
+        // hrIntervalMinutes (no per-vital intervals), so we share it across the board.
+        measurementSettings?.let { settings ->
+            if (settings.hrEnabled) send(CRPProtocol.enableTimingHeartRate(settings.hrIntervalMinutes))
+            if (settings.hrvEnabled) send(CRPProtocol.enableTimingHRV(settings.hrIntervalMinutes))
+            if (settings.stressEnabled) send(CRPProtocol.enableTimingStress(settings.hrIntervalMinutes))
+            if (settings.spo2Enabled) send(CRPProtocol.enableTimingSpO2(settings.hrIntervalMinutes))
+            if (settings.temperatureEnabled) send(CRPProtocol.enableTimingTemp())
+        }
     }
 
     override fun handle(event: RingDecodedEvent) {
@@ -55,6 +71,25 @@ class CRPSyncEngine(private val writer: RingCommandWriter?) : RingSyncEngine {
     override fun applyUserProfile(profile: UserProfileValues) {
         this.profile = profile
         send(userInfoFrame(profile))
+    }
+
+    override fun setMeasurementSettings(settings: MeasurementSettings?) {
+        measurementSettings = settings
+    }
+
+    override fun applyMeasurementSettings(settings: MeasurementSettings) {
+        measurementSettings = settings
+        // Re-send vital enable commands with the updated settings.
+        if (settings.hrEnabled) send(CRPProtocol.enableTimingHeartRate(settings.hrIntervalMinutes))
+        else send(CRPProtocol.disableTimingHeartRate())
+        if (settings.hrvEnabled) send(CRPProtocol.enableTimingHRV(settings.hrIntervalMinutes))
+        else send(CRPProtocol.disableTimingHRV())
+        if (settings.stressEnabled) send(CRPProtocol.enableTimingStress(settings.hrIntervalMinutes))
+        else send(CRPProtocol.disableTimingStress())
+        if (settings.spo2Enabled) send(CRPProtocol.enableTimingSpO2(settings.hrIntervalMinutes))
+        else send(CRPProtocol.disableTimingSpO2())
+        if (settings.temperatureEnabled) send(CRPProtocol.enableTimingTemp())
+        else send(CRPProtocol.disableTimingTemp())
     }
 
     override fun resyncTime() { send(CRPProtocol.setTime()) }

--- a/app/src/main/java/com/pulseloop/ring/CRPSyncEngine.kt
+++ b/app/src/main/java/com/pulseloop/ring/CRPSyncEngine.kt
@@ -39,6 +39,25 @@ class CRPSyncEngine(private val writer: RingCommandWriter?) : RingSyncEngine {
             if (settings.spo2Enabled) send(CRPProtocol.enableTimingSpO2(settings.hrIntervalMinutes))
             if (settings.temperatureEnabled) send(CRPProtocol.enableTimingTemp())
         }
+        // Pull the day's stored all-day timeline. runStartup() IS the poll pass (RingSyncWorker's
+        // ~30-min background sync and the foreground syncNow() both re-invoke it), so this runs at
+        // the app's configured polling cadence; the ring samples at hrIntervalMinutes (above).
+        // The ring only emits history replies once asked — so this also produces the group-7/2
+        // reply frames in a diagnostic capture, which is what we need to finish decoding them.
+        // NOTE: the replies are currently acknowledged, not yet parsed into samples
+        // (CRPDecoder.decodeHistoryOrDeviceInfoResponse is a TODO pending that capture).
+        queryAllHistory()
+    }
+
+    /** Request the stored all-day timelines the ring has accumulated (group 7 for HR/stress/HRV/
+     *  SpO2, group 2 for sleep/temp). Vendor `u3/g1.java` fires the same set on its sync pass. */
+    private fun queryAllHistory() {
+        send(CRPProtocol.queryHistoryHeartRate())
+        send(CRPProtocol.queryHistorySpO2())
+        send(CRPProtocol.queryHistoryHRV())
+        send(CRPProtocol.queryHistoryStress())
+        send(CRPProtocol.queryHistoryTemp())
+        send(CRPProtocol.queryHistorySleep())
     }
 
     override fun handle(event: RingDecodedEvent) {

--- a/app/src/main/java/com/pulseloop/ring/CRPSyncEngine.kt
+++ b/app/src/main/java/com/pulseloop/ring/CRPSyncEngine.kt
@@ -26,6 +26,8 @@ class CRPSyncEngine(private val writer: RingCommandWriter?) : RingSyncEngine {
         // Set the device clock first (matches the vendor's connect handshake), then user info so
         // the ring's step/calorie algorithm has real inputs.
         send(CRPProtocol.setTime())
+        // Query firmware version so the UI doesn't show "Firmware: reading" (zaggash's report).
+        send(CRPProtocol.queryFirmwareVersion())
         profile?.let { send(userInfoFrame(it)) }
         // Enable vital monitoring only when the user has configured it (mirrors the vendor app's
         // connect flow). Uses the user's polling interval for all vital types — the CRP protocol
@@ -79,7 +81,7 @@ class CRPSyncEngine(private val writer: RingCommandWriter?) : RingSyncEngine {
 
     override fun applyMeasurementSettings(settings: MeasurementSettings) {
         measurementSettings = settings
-        // Re-send vital enable commands with the updated settings.
+        // Re-send vital enable/disable commands with the updated settings.
         if (settings.hrEnabled) send(CRPProtocol.enableTimingHeartRate(settings.hrIntervalMinutes))
         else send(CRPProtocol.disableTimingHeartRate())
         if (settings.hrvEnabled) send(CRPProtocol.enableTimingHRV(settings.hrIntervalMinutes))

--- a/app/src/test/java/com/pulseloop/ring/CRPDecoderTest.kt
+++ b/app/src/test/java/com/pulseloop/ring/CRPDecoderTest.kt
@@ -12,7 +12,6 @@ class CRPDecoderTest {
 
     private val fdd1 = CRPUUIDs.CHAR_STEPS_NOTIFY
     private val fdd3 = CRPUUIDs.CHAR_CMD_NOTIFY
-    private val hr = CRPUUIDs.CHAR_HEART_RATE_MEASURE
 
     @Test
     fun `current-steps push decodes little-endian steps distance calories`() {
@@ -43,21 +42,51 @@ class CRPDecoderTest {
         assertTrue(CRPDecoder.decode(byteArrayOf(1, 2), fdd1).isEmpty())
     }
 
+    // ---- Real-time vital results: framed group-1 replies on fdd3 (g1/a.java 664–712). ----
+    // This ring does NOT use the standard 2a37 characteristic — HR comes back as a framed reply.
+
     @Test
-    fun `heart rate 2a37 reads bpm from byte1 when the 0x0400 marker is present`() {
-        // [status, bpm=72, 0x00, 0x04] -> marker bytes[2..3] == 0x0400
-        val hrs = CRPDecoder.decode(byteArrayOf(0x00, 72, 0x00, 0x04), hr)[0] as RingDecodedEvent.HeartRateSample
-        assertEquals(72, hrs.bpm)
+    fun `group1 cmd9 framed reply decodes heart rate from payload0`() {
+        // The exact frame the ring returned for zaggash's Measure press (issue #29): HR = 0x4a = 74.
+        val frame = CRPProtocol.frame(1, CRPCommands.CMD_RESULT_HR, byteArrayOf(0x4a))
+        val hrs = CRPDecoder.decode(frame, fdd3)[0] as RingDecodedEvent.HeartRateSample
+        assertEquals(74, hrs.bpm)
     }
 
     @Test
-    fun `heart rate 2a37 with wrong marker is dropped`() {
-        assertTrue(CRPDecoder.decode(byteArrayOf(0x00, 72, 0x00, 0x08), hr).isEmpty())
+    fun `group1 cmd9 out-of-range bpm is dropped`() {
+        assertTrue(CRPDecoder.decode(CRPProtocol.frame(1, CRPCommands.CMD_RESULT_HR, byteArrayOf(0)), fdd3).isEmpty())
     }
 
     @Test
-    fun `heart rate 2a37 with zero bpm is dropped`() {
-        assertTrue(CRPDecoder.decode(byteArrayOf(0x00, 0, 0x00, 0x04), hr).isEmpty())
+    fun `group1 cmd10 decodes hrv, cmd11 spo2, cmd14 stress from payload0`() {
+        val hrv = CRPDecoder.decode(CRPProtocol.frame(1, CRPCommands.CMD_RESULT_HRV, byteArrayOf(45)), fdd3)[0]
+        assertEquals(45, (hrv as RingDecodedEvent.HrvSample).value)
+        val spo2 = CRPDecoder.decode(CRPProtocol.frame(1, CRPCommands.CMD_RESULT_SPO2, byteArrayOf(98)), fdd3)[0]
+        assertEquals(98, (spo2 as RingDecodedEvent.Spo2Result).value)
+        val stress = CRPDecoder.decode(CRPProtocol.frame(1, CRPCommands.CMD_RESULT_STRESS, byteArrayOf(37)), fdd3)[0]
+        assertEquals(37, (stress as RingDecodedEvent.StressSample).value)
+    }
+
+    @Test
+    fun `group1 cmd32 decodes temperature as two-byte tenths of a degree`() {
+        // e1/m.a: (payload[1]<<8 | payload[0]) / 10 -> 365 => 36.5 C
+        val frame = CRPProtocol.frame(1, CRPCommands.CMD_RESULT_TEMP, byteArrayOf(0x6D, 0x01))
+        val temp = CRPDecoder.decode(frame, fdd3)[0] as RingDecodedEvent.TemperatureSample
+        assertEquals(36.5, temp.celsius, 0.001)
+    }
+
+    @Test
+    fun `group1 out-of-range temperature is dropped`() {
+        // 0x0064 = 100 -> 10.0 C, below the 28..50 validity window.
+        assertTrue(CRPDecoder.decode(CRPProtocol.frame(1, CRPCommands.CMD_RESULT_TEMP, byteArrayOf(0x64, 0x00)), fdd3).isEmpty())
+    }
+
+    @Test
+    fun `unrecognised group1 cmd is acked, not dropped`() {
+        // cmd 0 (set-user-info ack) isn't a vital result -> CommandAck, no fabricated sample.
+        val ev = CRPDecoder.decode(CRPProtocol.frame(1, 0, byteArrayOf(0)), fdd3)[0]
+        assertTrue(ev is RingDecodedEvent.CommandAck)
     }
 
     @Test

--- a/app/src/test/java/com/pulseloop/ring/CRPProtocolTest.kt
+++ b/app/src/test/java/com/pulseloop/ring/CRPProtocolTest.kt
@@ -77,6 +77,30 @@ class CRPProtocolTest {
     }
 
     @Test
+    fun `spot measure toggles use the vendor opcodes hrv10 stress14 temp32`() {
+        // b1/u.d, b1/h0.d, b1/i0.d — start(1)/stop(0) on group 1.
+        assertArrayEquals(byteArrayOf(0xFD.toByte(), 0xDA.toByte(), 0x10, 7, 1, 10, 1), CRPProtocol.measureHRV(true))
+        assertArrayEquals(byteArrayOf(0xFD.toByte(), 0xDA.toByte(), 0x10, 7, 1, 10, 0), CRPProtocol.measureHRV(false))
+        assertArrayEquals(byteArrayOf(0xFD.toByte(), 0xDA.toByte(), 0x10, 7, 1, 14, 1), CRPProtocol.measureStress(true))
+        assertArrayEquals(byteArrayOf(0xFD.toByte(), 0xDA.toByte(), 0x10, 7, 1, 32, 1), CRPProtocol.measureTemp(true))
+    }
+
+    @Test
+    fun `spot measure opcode matches the result opcode the ring replies on`() {
+        // The measurement echoes back on its own cmd byte — guard against these drifting apart.
+        assertEquals(CRPCommands.CMD_MEASURE_HRV, CRPCommands.CMD_RESULT_HRV)
+        assertEquals(CRPCommands.CMD_MEASURE_STRESS, CRPCommands.CMD_RESULT_STRESS)
+        assertEquals(CRPCommands.CMD_MEASURE_TEMP, CRPCommands.CMD_RESULT_TEMP)
+    }
+
+    @Test
+    fun `temp all-day timing toggles cmd13 with an enable byte, distinct from measure cmd32`() {
+        // b1/i0.c: q.c(1,13,[enable]) — NOT cmd 32 (that's the spot-measure toggle, b1/i0.d).
+        assertArrayEquals(byteArrayOf(0xFD.toByte(), 0xDA.toByte(), 0x10, 7, 1, 13, 1), CRPProtocol.enableTimingTemp())
+        assertArrayEquals(byteArrayOf(0xFD.toByte(), 0xDA.toByte(), 0x10, 7, 1, 13, 0), CRPProtocol.disableTimingTemp())
+    }
+
+    @Test
     fun `findDevice is group9 cmd2`() {
         assertArrayEquals(byteArrayOf(0xFD.toByte(), 0xDA.toByte(), 0x10, 7, 9, 2, 1), CRPProtocol.findDevice(true))
     }

--- a/app/src/test/java/com/pulseloop/ring/CRPSyncEngineTest.kt
+++ b/app/src/test/java/com/pulseloop/ring/CRPSyncEngineTest.kt
@@ -16,18 +16,18 @@ class CRPSyncEngineTest {
     }
 
     @Test
-    fun `runStartup sends set-time, and user info once a profile is stored`() {
+    fun `runStartup sends set-time, firmware query, and user info once a profile is stored`() {
         val w = FakeWriter()
         val engine = CRPSyncEngine(w)
         engine.runStartup()
-        assertEquals(listOf(1 to 1), w.opcodes()) // set-time only, no profile yet
+        assertEquals(listOf(1 to 1, 7 to 1), w.opcodes()) // set-time then firmware query, no profile yet
 
         w.sent.clear()
         engine.setUserProfile(
             UserProfileValues(metric = true, gender = 1u, age = 30u, heightCm = 180u, weightKg = 75u),
         )
         engine.runStartup()
-        assertEquals(listOf(1 to 1, 1 to 0), w.opcodes()) // set-time then set-user-info
+        assertEquals(listOf(1 to 1, 7 to 1, 1 to 0), w.opcodes()) // set-time, firmware query, set-user-info
     }
 
     @Test

--- a/app/src/test/java/com/pulseloop/ring/CRPSyncEngineTest.kt
+++ b/app/src/test/java/com/pulseloop/ring/CRPSyncEngineTest.kt
@@ -15,19 +15,25 @@ class CRPSyncEngineTest {
         fun opcodes(): List<Pair<Int, Int>> = sent.map { it[4].toInt() to it[5].toInt() }
     }
 
+    /** The all-day history pull appended to every runStartup (the poll pass). Group 7 for
+     *  HR/SpO2/HRV/stress, group 2 for temp/sleep — see CRPProtocol.queryHistory*. */
+    private val historyQueries = listOf(7 to 4, 7 to 7, 7 to 6, 7 to 5, 2 to 48, 2 to 14)
+
     @Test
-    fun `runStartup sends set-time, firmware query, and user info once a profile is stored`() {
+    fun `runStartup sends set-time, firmware query, user info, then the history pull`() {
         val w = FakeWriter()
         val engine = CRPSyncEngine(w)
         engine.runStartup()
-        assertEquals(listOf(1 to 1, 7 to 1), w.opcodes()) // set-time then firmware query, no profile yet
+        // set-time, firmware query, then the history pull (no profile / no settings yet).
+        assertEquals(listOf(1 to 1, 7 to 1) + historyQueries, w.opcodes())
 
         w.sent.clear()
         engine.setUserProfile(
             UserProfileValues(metric = true, gender = 1u, age = 30u, heightCm = 180u, weightKg = 75u),
         )
         engine.runStartup()
-        assertEquals(listOf(1 to 1, 7 to 1, 1 to 0), w.opcodes()) // set-time, firmware query, set-user-info
+        // set-time, firmware query, set-user-info, then the history pull.
+        assertEquals(listOf(1 to 1, 7 to 1, 1 to 0) + historyQueries, w.opcodes())
     }
 
     @Test


### PR DESCRIPTION
Addresses **issue #29** — Colmi R11 (CRP "Da Rings") vitals not being pulled.

## What this does
Builds on the initial CRP driver to actually deliver vital data, verified against the decompiled Moyoung vendor app and zaggash's diagnostic capture.

### Fixes (the reported bug)
- **Vital decode was dropping everything.** `decodeFramedReply` collapsed every group-1 reply to a bare ack, so the ring's real-time HR (the `fdda100701094a` = 74 bpm in zaggash's log) was discarded. Now decodes group-1 vital results on the correct opcodes — `9=HR, 10=HRV, 11=SpO2, 14=stress, 32=temp` (per vendor `g1/a.java:664-712`), with vendor-faithful payloads and plausibility guards.
- **Build break + wrong command mappings** from the interim commit: restored `GROUP_HISTORY`, routed history queries to their real groups (7 for HR/stress/HRV/SpO2, 2 for sleep/temp), corrected temp all-day timing to cmd 13.

### Measure button
- Grabs **HR + SpO2** now (added `MANUAL_SPO2`; the button previously only sent HR). Both decode and persist through the existing pipeline.
- HRV/stress/temp are intentionally **not** spot-triggered — they're all-day metrics per the app's existing design (need sustained wear), pulled via the all-day path below.

### All-day / interval polling
- `runStartup()` (the poll pass) enables per-vital timing at the user's `hrIntervalMinutes` and now sends the group-7/group-2 `queryHistory*` commands, matching the vendor's sync pass.

## Known follow-up
History **reply decode** (`decodeHistoryOrDeviceInfoResponse`) still acks rather than parsing — deliberately, pending a hardware capture. The queries are now sent, so a fresh diagnostic export from an R11 will contain the reply frames needed to finish (and verify) the decode. This avoids shipping unverified byte layouts.

## Testing
- New/updated unit tests cover the framed HR reply from the issue-29 log, HRV/SpO2/stress/temp decode + guards, the spot-measure builders, temp timing opcodes, and the startup history pull.
- Full `:app:testDebugUnitTest` passes.