### PR TITLE
fix(crp): enable all-day monitoring on connect + decode R11 sleep history

### DIFF
--- a/app/src/main/java/com/pulseloop/ring/CRPDecoder.kt
+++ b/app/src/main/java/com/pulseloop/ring/CRPDecoder.kt
@@ -54,11 +54,16 @@ class CRPFrameAssembler {
  */
 object CRPDecoder {
 
-    fun decode(data: ByteArray, from: String, now: Instant = Instant.now()): List<RingDecodedEvent> {
+    fun decode(
+        data: ByteArray,
+        from: String,
+        now: Instant = Instant.now(),
+        zone: ZoneId = ZoneId.systemDefault(),
+    ): List<RingDecodedEvent> {
         val src = from.lowercase()
         return when {
             src.contains("fdd1") -> decodeCurrentSteps(data, now)
-            CRPProtocol.isFrameStart(data) -> decodeFramedReply(data, now)
+            CRPProtocol.isFrameStart(data) -> decodeFramedReply(data, now, zone)
             else -> emptyList()
         }
     }
@@ -77,7 +82,7 @@ object CRPDecoder {
      * Framed `fdd3` reply: `FD DA 10 <len> <group> <cmd> <payload>`.
      * Real-time vital results come on group 1; history queries on group 7; device info on group 7.
      */
-    private fun decodeFramedReply(frame: ByteArray, now: Instant): List<RingDecodedEvent> {
+    private fun decodeFramedReply(frame: ByteArray, now: Instant, zone: ZoneId): List<RingDecodedEvent> {
         if (frame.size < CRPProtocol.HEADER_SIZE) return emptyList()
         val group = frame[4].toInt() and 0xFF
         val cmd = frame[5].toInt() and 0xFF
@@ -98,7 +103,7 @@ object CRPDecoder {
         // non-empty capture pins the layout.
         if (group == CRPCommands.GROUP_HISTORY) {
             if (cmd == CRPCommands.CMD_QUERY_HISTORY_SLEEP) {
-                return decodeSleep(payload, now, ZoneId.systemDefault())
+                return decodeSleep(payload, now, zone)
             }
             return listOf(RingDecodedEvent.CommandAck(commandId = ((group shl 4) or (cmd and 0x0F)).toUByte()))
         }
@@ -167,10 +172,19 @@ object CRPDecoder {
      * to a clean 01:07→08:05 night (245 light / 110 deep / 63 REM minutes).
      *
      * Emitted as one [RingDecodedEvent.SleepTimeline] whose `stages` list is one entry per minute
-     * (the shape [EventPersistenceSubscriber] expects), matching [ColmiDecoder.decodeSleep]. The
-     * session start is anchored on the wake day (`today - dayIndex`) using the same evening-rollover
-     * rule Colmi uses: a first record later in the clock than the last means the night began before
-     * midnight, so the start offset is pulled back a day.
+     * (the shape [EventPersistenceSubscriber] expects), matching [ColmiDecoder.decodeSleep].
+     *
+     * Two deliberate departures from the vendor:
+     *  - The vendor extends the final record's state to the current wall-clock when it isn't awake
+     *    (an in-progress sleep). We don't — a completed night always ends on an awake record (which
+     *    contributes no sleep), so the only case affected is a sync taken mid-sleep, where we'd
+     *    rather show the night up to the last recorded transition than invent minutes up to "now".
+     *  - Session-start anchoring is ours, not the vendor's (its parser keeps minute-of-day only and
+     *    lets the UI place the date from `dayIndex`). We anchor on the wake day (`today - dayIndex`)
+     *    with the same evening-rollover rule as Colmi: a first record later in the clock than the
+     *    last means the night began before midnight, so the offset is pulled back a day. NOTE: this
+     *    assumes `dayIndex` is the WAKE day — verified against a post-midnight capture; an
+     *    evening-start night is not yet capture-confirmed.
      */
     private fun decodeSleep(payload: ByteArray, now: Instant, zone: ZoneId): List<RingDecodedEvent> {
         // [dayIndex] + N*[state,hour,minute]; the vendor rejects any other shape outright.
@@ -189,13 +203,17 @@ object CRPDecoder {
             val state = payload[off].toInt() and 0xFF
             val hour = payload[off + 1].toInt() and 0xFF
             val minute = payload[off + 2].toInt() and 0xFF
-            if (prevState >= 0) {
-                // The segment ending at this record carries the PREVIOUS record's state.
-                val duration = sleepSegmentMinutes(prevHour, prevMinute, hour, minute)
-                if (duration in 1..MAX_SLEEP_MINUTES) {
-                    val stage = mapSleepState(prevState)
-                    repeat(duration) { stages.add(stage) }
-                }
+            // Guard against a corrupt record (byte is 0..255): a bad hour would otherwise anchor the
+            // whole night wrong and could allocate a giant per-minute list.
+            if (hour > 23 || minute > 59) continue
+            val duration = sleepSegmentMinutes(prevHour, prevMinute, hour, minute)
+            // A negative duration is an out-of-order record; the vendor skips it entirely without
+            // advancing its cursor, so neither the segment nor the anchor moves.
+            if (duration < 0) continue
+            // The segment ending at this record carries the PREVIOUS record's state.
+            if (prevState >= 0 && duration <= MAX_SLEEP_MINUTES) {
+                val stage = mapSleepState(prevState)
+                repeat(duration) { stages.add(stage) }
             }
             if (firstMinuteOfDay < 0) firstMinuteOfDay = hour * 60 + minute
             lastMinuteOfDay = hour * 60 + minute

--- a/app/src/main/java/com/pulseloop/ring/CRPDecoder.kt
+++ b/app/src/main/java/com/pulseloop/ring/CRPDecoder.kt
@@ -1,6 +1,7 @@
 package com.pulseloop.ring
 
 import java.time.Instant
+import java.time.ZoneId
 
 /**
  * Reassembles CRP command replies (`fdd3`) that span multiple BLE notifications. A logical frame
@@ -92,6 +93,16 @@ object CRPDecoder {
             return decodeHistoryOrDeviceInfoResponse(cmd, payload, now)
         }
 
+        // Group 2: sleep + temperature history (decompiled `b1/e0.c`/`e0.d`). Sleep is confirmed
+        // against a hardware capture (zaggash's R11, issue #29); temp history stays an ack until a
+        // non-empty capture pins the layout.
+        if (group == CRPCommands.GROUP_HISTORY) {
+            if (cmd == CRPCommands.CMD_QUERY_HISTORY_SLEEP) {
+                return decodeSleep(payload, now, ZoneId.systemDefault())
+            }
+            return listOf(RingDecodedEvent.CommandAck(commandId = ((group shl 4) or (cmd and 0x0F)).toUByte()))
+        }
+
         // Unknown group/cmd — ack.
         return listOf(RingDecodedEvent.CommandAck(commandId = ((group shl 4) or (cmd and 0x0F)).toUByte()))
     }
@@ -144,6 +155,78 @@ object CRPDecoder {
     private fun decodeHistoryOrDeviceInfoResponse(cmd: Int, payload: ByteArray, now: Instant): List<RingDecodedEvent> {
         return listOf(RingDecodedEvent.CommandAck(commandId = ((CRPCommands.GROUP_DEVICE_INFO shl 4) or (cmd and 0x0F)).toUByte()))
     }
+
+    /**
+     * Decode a sleep-history reply (`group 2 / cmd 14`), a faithful port of the vendor parser
+     * `e1/j.b` (Moyoung "Da Rings"). Layout: `[dayIndex]` then repeating 3-byte records
+     * `[state, hour, minute]`, where a record marks the moment sleep entered `state` and that state
+     * runs until the NEXT record's timestamp (state 0=awake, 1=light, 2=deep, 3=rem). The vendor
+     * requires `length % 3 == 1` (one day byte + N whole records); anything else is malformed.
+     *
+     * Confirmed against a hardware capture (issue #29): a `dayIndex 0` reply of 26 records decoded
+     * to a clean 01:07→08:05 night (245 light / 110 deep / 63 REM minutes).
+     *
+     * Emitted as one [RingDecodedEvent.SleepTimeline] whose `stages` list is one entry per minute
+     * (the shape [EventPersistenceSubscriber] expects), matching [ColmiDecoder.decodeSleep]. The
+     * session start is anchored on the wake day (`today - dayIndex`) using the same evening-rollover
+     * rule Colmi uses: a first record later in the clock than the last means the night began before
+     * midnight, so the start offset is pulled back a day.
+     */
+    private fun decodeSleep(payload: ByteArray, now: Instant, zone: ZoneId): List<RingDecodedEvent> {
+        // [dayIndex] + N*[state,hour,minute]; the vendor rejects any other shape outright.
+        if (payload.size < 4 || payload.size % 3 != 1) return emptyList()
+        val dayIndex = payload[0].toInt() and 0xFF
+        val recordCount = (payload.size - 1) / 3
+
+        val stages = mutableListOf<SleepStage>()
+        var firstMinuteOfDay = -1
+        var lastMinuteOfDay = 0
+        var prevState = -1
+        var prevHour = 0
+        var prevMinute = 0
+        for (k in 0 until recordCount) {
+            val off = 1 + k * 3
+            val state = payload[off].toInt() and 0xFF
+            val hour = payload[off + 1].toInt() and 0xFF
+            val minute = payload[off + 2].toInt() and 0xFF
+            if (prevState >= 0) {
+                // The segment ending at this record carries the PREVIOUS record's state.
+                val duration = sleepSegmentMinutes(prevHour, prevMinute, hour, minute)
+                if (duration in 1..MAX_SLEEP_MINUTES) {
+                    val stage = mapSleepState(prevState)
+                    repeat(duration) { stages.add(stage) }
+                }
+            }
+            if (firstMinuteOfDay < 0) firstMinuteOfDay = hour * 60 + minute
+            lastMinuteOfDay = hour * 60 + minute
+            prevState = state
+            prevHour = hour
+            prevMinute = minute
+        }
+        if (stages.isEmpty()) return emptyList()
+
+        val startOffset = if (firstMinuteOfDay > lastMinuteOfDay) firstMinuteOfDay - 1440 else firstMinuteOfDay
+        val wakeDay = now.atZone(zone).toLocalDate().minusDays(dayIndex.toLong())
+        val start = wakeDay.atStartOfDay(zone).plusMinutes(startOffset.toLong()).toInstant()
+        return listOf(RingDecodedEvent.SleepTimeline(_timestamp = start, stages = stages))
+    }
+
+    /** Minutes from a previous `hh:mm` to this one, wrapping across midnight (vendor `e1/j.a`). */
+    private fun sleepSegmentMinutes(prevHour: Int, prevMinute: Int, hour: Int, minute: Int): Int {
+        val wrappedHour = if (prevHour > hour) hour + 24 else hour
+        return ((wrappedHour - prevHour) * 60 + minute) - prevMinute
+    }
+
+    /** Vendor `e1/j.c` state codes → shared [SleepStage]. */
+    private fun mapSleepState(state: Int): SleepStage = when (state) {
+        0 -> SleepStage.AWAKE
+        1 -> SleepStage.LIGHT
+        2 -> SleepStage.DEEP
+        3 -> SleepStage.REM
+        else -> SleepStage.UNKNOWN
+    }
+
+    private const val MAX_SLEEP_MINUTES = 24 * 60
 
     /** Little-endian unsigned 3-byte int at [offset]. */
     private fun le3(data: ByteArray, offset: Int): Int =

--- a/app/src/main/java/com/pulseloop/ring/CRPDecoder.kt
+++ b/app/src/main/java/com/pulseloop/ring/CRPDecoder.kt
@@ -53,6 +53,12 @@ class CRPFrameAssembler {
  *   Other cmd values → command acknowledgment.
  */
 object CRPDecoder {
+    /** Longest plausible single sleep segment; a longer one is a corrupt record, not real sleep. */
+    private const val MAX_SLEEP_MINUTES = 24 * 60
+    /** Awake run that separates two sleep bouts (night vs nap) — matches the persistence layer. */
+    private const val SESSION_GAP_MINUTES = 60
+    /** CRPHistoryDay caps at 14 days ago; a larger dayIndex is a corrupt reply. */
+    private const val MAX_HISTORY_DAY = 14
 
     fun decode(
         data: ByteArray,
@@ -171,8 +177,11 @@ object CRPDecoder {
      * Confirmed against a hardware capture (issue #29): a `dayIndex 0` reply of 26 records decoded
      * to a clean 01:07→08:05 night (245 light / 110 deep / 63 REM minutes).
      *
-     * Emitted as one [RingDecodedEvent.SleepTimeline] whose `stages` list is one entry per minute
-     * (the shape [EventPersistenceSubscriber] expects), matching [ColmiDecoder.decodeSleep].
+     * Emitted as [RingDecodedEvent.SleepTimeline]s whose `stages` lists are one entry per minute
+     * (the shape [EventPersistenceSubscriber] expects), matching [ColmiDecoder.decodeSleep]. A day's
+     * reply can hold more than one sleep bout (a night plus a nap), so we split into a separate
+     * timeline at any awake run of [SESSION_GAP_MINUTES]+ (the same gap the persistence layer uses
+     * to separate sessions). Short mid-night wakes stay inside their bout as awake minutes.
      *
      * Two deliberate departures from the vendor:
      *  - The vendor extends the final record's state to the current wall-clock when it isn't awake
@@ -180,22 +189,28 @@ object CRPDecoder {
      *    contributes no sleep), so the only case affected is a sync taken mid-sleep, where we'd
      *    rather show the night up to the last recorded transition than invent minutes up to "now".
      *  - Session-start anchoring is ours, not the vendor's (its parser keeps minute-of-day only and
-     *    lets the UI place the date from `dayIndex`). We anchor on the wake day (`today - dayIndex`)
-     *    with the same evening-rollover rule as Colmi: a first record later in the clock than the
-     *    last means the night began before midnight, so the offset is pulled back a day. NOTE: this
-     *    assumes `dayIndex` is the WAKE day — verified against a post-midnight capture; an
+     *    lets the UI place the date from `dayIndex`). We anchor the FIRST record on the wake day
+     *    (`today - dayIndex`) with the same evening-rollover rule as Colmi — a first record later in
+     *    the clock than the last means the night began before midnight — then place every later bout
+     *    by its elapsed offset from that anchor, which carries naps onto the correct day for free.
+     *    NOTE: this assumes `dayIndex` is the WAKE day — verified against a post-midnight capture; an
      *    evening-start night is not yet capture-confirmed.
      */
     private fun decodeSleep(payload: ByteArray, now: Instant, zone: ZoneId): List<RingDecodedEvent> {
         // [dayIndex] + N*[state,hour,minute]; the vendor rejects any other shape outright.
         if (payload.size < 4 || payload.size % 3 != 1) return emptyList()
         val dayIndex = payload[0].toInt() and 0xFF
+        // CRPHistoryDay tops out at 14 days ago; a wilder value is a corrupt reply, not a real day.
+        if (dayIndex > MAX_HISTORY_DAY) return emptyList()
         val recordCount = (payload.size - 1) / 3
 
-        val stages = mutableListOf<SleepStage>()
+        // Pass 1: fold the records into monotonic transition points, each an elapsed-minute offset
+        // from the first valid record and the state that begins there. Out-of-order / corrupt
+        // records are skipped without advancing the cursor, matching the vendor's `iA >= 0` guard.
+        val transitions = mutableListOf<Transition>()
         var firstMinuteOfDay = -1
         var lastMinuteOfDay = 0
-        var prevState = -1
+        var elapsed = 0
         var prevHour = 0
         var prevMinute = 0
         for (k in 0 until recordCount) {
@@ -203,30 +218,55 @@ object CRPDecoder {
             val state = payload[off].toInt() and 0xFF
             val hour = payload[off + 1].toInt() and 0xFF
             val minute = payload[off + 2].toInt() and 0xFF
-            // Guard against a corrupt record (byte is 0..255): a bad hour would otherwise anchor the
-            // whole night wrong and could allocate a giant per-minute list.
             if (hour > 23 || minute > 59) continue
-            val duration = sleepSegmentMinutes(prevHour, prevMinute, hour, minute)
-            // A negative duration is an out-of-order record; the vendor skips it entirely without
-            // advancing its cursor, so neither the segment nor the anchor moves.
-            if (duration < 0) continue
-            // The segment ending at this record carries the PREVIOUS record's state.
-            if (prevState >= 0 && duration <= MAX_SLEEP_MINUTES) {
-                val stage = mapSleepState(prevState)
-                repeat(duration) { stages.add(stage) }
+            if (transitions.isEmpty()) {
+                firstMinuteOfDay = hour * 60 + minute
+                lastMinuteOfDay = firstMinuteOfDay
+                transitions.add(Transition(0, state))
+            } else {
+                val duration = sleepSegmentMinutes(prevHour, prevMinute, hour, minute)
+                if (duration < 0 || duration > MAX_SLEEP_MINUTES) continue
+                elapsed += duration
+                lastMinuteOfDay = hour * 60 + minute
+                transitions.add(Transition(elapsed, state))
             }
-            if (firstMinuteOfDay < 0) firstMinuteOfDay = hour * 60 + minute
-            lastMinuteOfDay = hour * 60 + minute
-            prevState = state
             prevHour = hour
             prevMinute = minute
         }
-        if (stages.isEmpty()) return emptyList()
+        if (transitions.size < 2) return emptyList()
 
+        // Anchor the first record; every bout is then just an offset from it.
         val startOffset = if (firstMinuteOfDay > lastMinuteOfDay) firstMinuteOfDay - 1440 else firstMinuteOfDay
         val wakeDay = now.atZone(zone).toLocalDate().minusDays(dayIndex.toLong())
-        val start = wakeDay.atStartOfDay(zone).plusMinutes(startOffset.toLong()).toInstant()
-        return listOf(RingDecodedEvent.SleepTimeline(_timestamp = start, stages = stages))
+        val anchor = wakeDay.atStartOfDay(zone).plusMinutes(startOffset.toLong()).toInstant()
+
+        // Pass 2: each transition's state runs until the next; split bouts on a long awake gap.
+        val events = mutableListOf<RingDecodedEvent>()
+        var boutStages = mutableListOf<SleepStage>()
+        var boutStartElapsed = 0
+        for (i in 0 until transitions.size - 1) {
+            val segment = transitions[i]
+            val duration = transitions[i + 1].elapsed - segment.elapsed
+            if (duration <= 0) continue
+            val stage = mapSleepState(segment.state)
+            if (stage == SleepStage.AWAKE && duration >= SESSION_GAP_MINUTES) {
+                emitSleepBout(events, anchor, boutStartElapsed, boutStages)
+                boutStages = mutableListOf()
+                continue
+            }
+            if (boutStages.isEmpty()) boutStartElapsed = segment.elapsed
+            repeat(duration) { boutStages.add(stage) }
+        }
+        emitSleepBout(events, anchor, boutStartElapsed, boutStages)
+        return events
+    }
+
+    private class Transition(val elapsed: Int, val state: Int)
+
+    /** Emit a bout as a SleepTimeline, unless it holds no actual sleep (awake-only). */
+    private fun emitSleepBout(into: MutableList<RingDecodedEvent>, anchor: Instant, startElapsed: Int, stages: List<SleepStage>) {
+        if (stages.none { it != SleepStage.AWAKE }) return
+        into.add(RingDecodedEvent.SleepTimeline(_timestamp = anchor.plusSeconds(startElapsed * 60L), stages = stages))
     }
 
     /** Minutes from a previous `hh:mm` to this one, wrapping across midnight (vendor `e1/j.a`). */
@@ -243,8 +283,6 @@ object CRPDecoder {
         3 -> SleepStage.REM
         else -> SleepStage.UNKNOWN
     }
-
-    private const val MAX_SLEEP_MINUTES = 24 * 60
 
     /** Little-endian unsigned 3-byte int at [offset]. */
     private fun le3(data: ByteArray, offset: Int): Int =

--- a/app/src/main/java/com/pulseloop/ring/CRPSyncEngine.kt
+++ b/app/src/main/java/com/pulseloop/ring/CRPSyncEngine.kt
@@ -9,16 +9,20 @@ package com.pulseloop.ring
  * Scope: clock + user-info handshake, spot HR + SpO2 (Measure button), all-day vital timing
  * enable/disable driven by [MeasurementSettings], find-device, factory reset. Steps and battery
  * arrive as autonomous pushes/reads (see [CRPDriver]). HRV / stress / temperature are all-day
- * metrics — their timing is enabled here and live results decode via [CRPDecoder], but pulling the
- * stored day timeline (group-7/group-2 history queries) is still TODO pending a hardware capture.
+ * metrics — their timing is enabled here and live results decode via [CRPDecoder]. Of the stored
+ * day timelines, sleep (group-2/cmd-14) is decoded ([CRPDecoder.decodeSleep], confirmed against a
+ * hardware capture); the group-7 vital histories still land as acks pending a non-empty capture.
  */
 class CRPSyncEngine(private val writer: RingCommandWriter?) : RingSyncEngine {
 
     private var profile: UserProfileValues? = null
 
     /** User-chosen all-day measurement config. Applied in the connect handshake and updatable
-     *  live via [applyMeasurementSettings]. `null` ⇒ the user has never saved one, so the engine
-     *  skips the vital enable commands (the ring's own settings are the source of truth). */
+     *  live via [applyMeasurementSettings]. `null` ⇒ the user has never saved one; unlike QRing/YCBT
+     *  the CRP ring exposes no way to read back its own config, so a fresh R11 ships with every
+     *  all-day monitor OFF and never records anything to sync. We therefore fall back to
+     *  [MeasurementSettings.ALL_ON_DEFAULT] (matching how [ColmiSyncEngine] force-enables on connect)
+     *  so the day timeline actually accumulates. */
     private var measurementSettings: MeasurementSettings? = null
 
     override fun runStartup() {
@@ -28,17 +32,11 @@ class CRPSyncEngine(private val writer: RingCommandWriter?) : RingSyncEngine {
         // Query firmware version so the UI doesn't show "Firmware: reading" (zaggash's report).
         send(CRPProtocol.queryFirmwareVersion())
         profile?.let { send(userInfoFrame(it)) }
-        // Enable vital monitoring only when the user has configured it (mirrors the vendor app's
-        // connect flow). Uses the user's polling interval for all vital types — the CRP protocol
-        // takes a single interval byte per enable command, and MeasurementSettings only exposes
-        // hrIntervalMinutes (no per-vital intervals), so we share it across the board.
-        measurementSettings?.let { settings ->
-            if (settings.hrEnabled) send(CRPProtocol.enableTimingHeartRate(settings.hrIntervalMinutes))
-            if (settings.hrvEnabled) send(CRPProtocol.enableTimingHRV(settings.hrIntervalMinutes))
-            if (settings.stressEnabled) send(CRPProtocol.enableTimingStress(settings.hrIntervalMinutes))
-            if (settings.spo2Enabled) send(CRPProtocol.enableTimingSpO2(settings.hrIntervalMinutes))
-            if (settings.temperatureEnabled) send(CRPProtocol.enableTimingTemp())
-        }
+        // Enable all-day vital monitoring. A fresh ring has these OFF, so without this the ring
+        // stores no HR/SpO2/HRV/stress/temperature history and every history query below returns an
+        // empty reply (issue #29, zaggash's full-day capture). Default to ALL_ON until the user
+        // saves their own config, then honour it exactly.
+        applyTimingSettings(measurementSettings ?: MeasurementSettings.ALL_ON_DEFAULT)
         // Pull the day's stored all-day timeline. runStartup() IS the poll pass (RingSyncWorker's
         // ~30-min background sync and the foreground syncNow() both re-invoke it), so this runs at
         // the app's configured polling cadence; the ring samples at hrIntervalMinutes (above).
@@ -101,7 +99,14 @@ class CRPSyncEngine(private val writer: RingCommandWriter?) : RingSyncEngine {
 
     override fun applyMeasurementSettings(settings: MeasurementSettings) {
         measurementSettings = settings
-        // Re-send vital enable/disable commands with the updated settings.
+        applyTimingSettings(settings)
+    }
+
+    /** Send the all-day enable/disable command for every vital. The CRP protocol takes a single
+     *  interval byte per enable, and [MeasurementSettings] carries only [MeasurementSettings.hrIntervalMinutes]
+     *  (no per-vital cadence), so the HR interval is shared across the board. Disabled vitals are
+     *  explicitly turned off so a reconnect can't leave a previously-enabled monitor running. */
+    private fun applyTimingSettings(settings: MeasurementSettings) {
         if (settings.hrEnabled) send(CRPProtocol.enableTimingHeartRate(settings.hrIntervalMinutes))
         else send(CRPProtocol.disableTimingHeartRate())
         if (settings.hrvEnabled) send(CRPProtocol.enableTimingHRV(settings.hrIntervalMinutes))

--- a/app/src/main/java/com/pulseloop/ring/CRPSyncEngine.kt
+++ b/app/src/main/java/com/pulseloop/ring/CRPSyncEngine.kt
@@ -34,8 +34,12 @@ class CRPSyncEngine(private val writer: RingCommandWriter?) : RingSyncEngine {
         profile?.let { send(userInfoFrame(it)) }
         // Enable all-day vital monitoring. A fresh ring has these OFF, so without this the ring
         // stores no HR/SpO2/HRV/stress/temperature history and every history query below returns an
-        // empty reply (issue #29, zaggash's full-day capture). Default to ALL_ON until the user
-        // saves their own config, then honour it exactly.
+        // empty reply (issue #29, zaggash's full-day capture). When the user has saved a config we
+        // honour it exactly (interval included); until then we fall back to ALL_ON_DEFAULT, whose
+        // interval matches DeviceMeasurementConfigEntity's own default — i.e. the same app-wide
+        // sampling cadence every other ring uses, not a CRP-specific value. The Measurement Settings
+        // screen writes that config, and its interval flows straight back here via
+        // RingSyncCoordinator's loadMeasurementSettings.
         applyTimingSettings(measurementSettings ?: MeasurementSettings.ALL_ON_DEFAULT)
         // Pull the day's stored all-day timeline. runStartup() IS the poll pass (RingSyncWorker's
         // ~30-min background sync and the foreground syncNow() both re-invoke it), so this runs at

--- a/app/src/test/java/com/pulseloop/ring/CRPDecoderTest.kt
+++ b/app/src/test/java/com/pulseloop/ring/CRPDecoderTest.kt
@@ -2,6 +2,8 @@ package com.pulseloop.ring
 
 import org.junit.Assert.*
 import org.junit.Test
+import java.time.Instant
+import java.time.ZoneId
 
 /**
  * Unit tests for CRP inbound decoding + reassembly ([CRPDecoder], [CRPFrameAssembler]) and the
@@ -152,6 +154,29 @@ class CRPDecoderTest {
     fun `sleep reply with only the day byte yields no timeline`() {
         val frame = CRPProtocol.frame(CRPCommands.GROUP_HISTORY, CRPCommands.CMD_QUERY_HISTORY_SLEEP, byteArrayOf(0x00))
         assertTrue(CRPDecoder.decode(frame, fdd3).none { it is RingDecodedEvent.SleepTimeline })
+    }
+
+    @Test
+    fun `post-midnight night anchors on the query day`() {
+        // dayIndex 0, light @01:00 → awake @08:00 = 7h light, starting today at 01:00.
+        val payload = byteArrayOf(0, /*light*/1, 1, 0, /*awake*/0, 8, 0)
+        val frame = CRPProtocol.frame(CRPCommands.GROUP_HISTORY, CRPCommands.CMD_QUERY_HISTORY_SLEEP, payload)
+        val now = Instant.parse("2026-07-22T11:00:00Z")
+        val timeline = CRPDecoder.decode(frame, fdd3, now, ZoneId.of("UTC")).single() as RingDecodedEvent.SleepTimeline
+        assertEquals(420, timeline.stages.size)
+        assertEquals(SleepStage.LIGHT, timeline.stages.first())
+        assertEquals(Instant.parse("2026-07-22T01:00:00Z"), timeline._timestamp)
+    }
+
+    @Test
+    fun `evening-start night rolls back before midnight`() {
+        // dayIndex 0, light @23:00 → awake @06:00 = 7h, so the night began the previous evening.
+        val payload = byteArrayOf(0, /*light*/1, 23, 0, /*awake*/0, 6, 0)
+        val frame = CRPProtocol.frame(CRPCommands.GROUP_HISTORY, CRPCommands.CMD_QUERY_HISTORY_SLEEP, payload)
+        val now = Instant.parse("2026-07-22T11:00:00Z")
+        val timeline = CRPDecoder.decode(frame, fdd3, now, ZoneId.of("UTC")).single() as RingDecodedEvent.SleepTimeline
+        assertEquals(420, timeline.stages.size)
+        assertEquals(Instant.parse("2026-07-21T23:00:00Z"), timeline._timestamp)
     }
 
     @Test

--- a/app/src/test/java/com/pulseloop/ring/CRPDecoderTest.kt
+++ b/app/src/test/java/com/pulseloop/ring/CRPDecoderTest.kt
@@ -180,6 +180,33 @@ class CRPDecoderTest {
     }
 
     @Test
+    fun `a night and a nap split into separate sessions on the long awake gap`() {
+        // light 01:00→03:00 (2h), awake 03:00→05:00 (2h ≥ gap → split), light 05:00→06:00 (nap), awake.
+        val payload = byteArrayOf(0, 1, 1, 0, 0, 3, 0, 1, 5, 0, 0, 6, 0)
+        val frame = CRPProtocol.frame(CRPCommands.GROUP_HISTORY, CRPCommands.CMD_QUERY_HISTORY_SLEEP, payload)
+        val now = Instant.parse("2026-07-22T12:00:00Z")
+        val events = CRPDecoder.decode(frame, fdd3, now, ZoneId.of("UTC")).filterIsInstance<RingDecodedEvent.SleepTimeline>()
+        assertEquals(2, events.size)
+        assertEquals(120, events[0].stages.size)
+        assertEquals(Instant.parse("2026-07-22T01:00:00Z"), events[0]._timestamp)
+        assertEquals(60, events[1].stages.size)
+        assertEquals(Instant.parse("2026-07-22T05:00:00Z"), events[1]._timestamp)
+    }
+
+    @Test
+    fun `a brief mid-night wake stays inside one session`() {
+        // light 60m + awake 30m (< gap, kept) + deep 90m = one 180-minute session.
+        val payload = byteArrayOf(0, 1, 1, 0, 0, 2, 0, 2, 2, 30, 0, 4, 0)
+        val frame = CRPProtocol.frame(CRPCommands.GROUP_HISTORY, CRPCommands.CMD_QUERY_HISTORY_SLEEP, payload)
+        val now = Instant.parse("2026-07-22T12:00:00Z")
+        val timeline = CRPDecoder.decode(frame, fdd3, now, ZoneId.of("UTC")).single() as RingDecodedEvent.SleepTimeline
+        assertEquals(180, timeline.stages.size)
+        assertEquals(60, timeline.stages.count { it == SleepStage.LIGHT })
+        assertEquals(30, timeline.stages.count { it == SleepStage.AWAKE })
+        assertEquals(90, timeline.stages.count { it == SleepStage.DEEP })
+    }
+
+    @Test
     fun `malformed sleep reply length is rejected`() {
         // 4 payload bytes ⇒ length % 3 != 1, which the vendor parser refuses.
         val frame = CRPProtocol.frame(CRPCommands.GROUP_HISTORY, CRPCommands.CMD_QUERY_HISTORY_SLEEP, byteArrayOf(0x00, 0x01, 0x02, 0x03))

--- a/app/src/test/java/com/pulseloop/ring/CRPDecoderTest.kt
+++ b/app/src/test/java/com/pulseloop/ring/CRPDecoderTest.kt
@@ -124,4 +124,43 @@ class CRPDecoderTest {
         assertTrue(driver.ingest(full.copyOfRange(0, 4), fdd3).isEmpty())
         assertEquals(1, driver.ingest(full.copyOfRange(4, full.size), fdd3).size)
     }
+
+    // ── Sleep history (group 2 / cmd 14, vendor e1/j.b) ──────────────────────────────────────
+
+    @Test
+    fun `sleep history reply decodes a full night into per-minute stages`() {
+        // Real payload from zaggash's Colmi R11 (issue #29): dayIndex 0 + 26 [state,hour,minute]
+        // records spanning 01:07 → 08:05. Wrapped in a group-2/cmd-14 frame as it arrives on fdd3.
+        val payload = hexToBytes(
+            "0001010702011301013702020901021302022501022d02030201031302031801032103" +
+                "040801040e03043001050002051501052502052d01053403053901061102063301063a03071301072c000805"
+        )
+        val frame = CRPProtocol.frame(CRPCommands.GROUP_HISTORY, CRPCommands.CMD_QUERY_HISTORY_SLEEP, payload)
+
+        val timeline = CRPDecoder.decode(frame, fdd3).single() as RingDecodedEvent.SleepTimeline
+        val stages = timeline.stages
+        // One entry per minute; the night totals 418 minutes of scored sleep.
+        assertEquals(418, stages.size)
+        assertEquals(245, stages.count { it == SleepStage.LIGHT })
+        assertEquals(110, stages.count { it == SleepStage.DEEP })
+        assertEquals(63, stages.count { it == SleepStage.REM })
+        // The closing awake record only terminates the night; it contributes no sleep minutes.
+        assertEquals(0, stages.count { it == SleepStage.AWAKE })
+    }
+
+    @Test
+    fun `sleep reply with only the day byte yields no timeline`() {
+        val frame = CRPProtocol.frame(CRPCommands.GROUP_HISTORY, CRPCommands.CMD_QUERY_HISTORY_SLEEP, byteArrayOf(0x00))
+        assertTrue(CRPDecoder.decode(frame, fdd3).none { it is RingDecodedEvent.SleepTimeline })
+    }
+
+    @Test
+    fun `malformed sleep reply length is rejected`() {
+        // 4 payload bytes ⇒ length % 3 != 1, which the vendor parser refuses.
+        val frame = CRPProtocol.frame(CRPCommands.GROUP_HISTORY, CRPCommands.CMD_QUERY_HISTORY_SLEEP, byteArrayOf(0x00, 0x01, 0x02, 0x03))
+        assertTrue(CRPDecoder.decode(frame, fdd3).none { it is RingDecodedEvent.SleepTimeline })
+    }
+
+    private fun hexToBytes(hex: String): ByteArray =
+        ByteArray(hex.length / 2) { ((hex[it * 2].digitToInt(16) shl 4) or hex[it * 2 + 1].digitToInt(16)).toByte() }
 }

--- a/app/src/test/java/com/pulseloop/ring/CRPSyncEngineTest.kt
+++ b/app/src/test/java/com/pulseloop/ring/CRPSyncEngineTest.kt
@@ -19,21 +19,47 @@ class CRPSyncEngineTest {
      *  HR/SpO2/HRV/stress, group 2 for temp/sleep — see CRPProtocol.queryHistory*. */
     private val historyQueries = listOf(7 to 4, 7 to 7, 7 to 6, 7 to 5, 2 to 48, 2 to 14)
 
+    /** The all-day monitor enables sent on connect (default ALL_ON): HR, HRV, stress, SpO2, temp —
+     *  see CRPSyncEngine.applyTimingSettings. Without these a fresh R11 records no history. */
+    private val timingEnables = listOf(1 to 6, 1 to 7, 1 to 39, 1 to 8, 1 to 13)
+
     @Test
-    fun `runStartup sends set-time, firmware query, user info, then the history pull`() {
+    fun `runStartup sends set-time, firmware query, user info, default monitor enables, then the history pull`() {
         val w = FakeWriter()
         val engine = CRPSyncEngine(w)
         engine.runStartup()
-        // set-time, firmware query, then the history pull (no profile / no settings yet).
-        assertEquals(listOf(1 to 1, 7 to 1) + historyQueries, w.opcodes())
+        // set-time, firmware query, default-on monitor enables, then the history pull.
+        assertEquals(listOf(1 to 1, 7 to 1) + timingEnables + historyQueries, w.opcodes())
 
         w.sent.clear()
         engine.setUserProfile(
             UserProfileValues(metric = true, gender = 1u, age = 30u, heightCm = 180u, weightKg = 75u),
         )
         engine.runStartup()
-        // set-time, firmware query, set-user-info, then the history pull.
-        assertEquals(listOf(1 to 1, 7 to 1, 1 to 0) + historyQueries, w.opcodes())
+        // set-time, firmware query, set-user-info, monitor enables, then the history pull.
+        assertEquals(listOf(1 to 1, 7 to 1, 1 to 0) + timingEnables + historyQueries, w.opcodes())
+    }
+
+    @Test
+    fun `runStartup honours a saved config, disabling the vitals the user turned off`() {
+        val w = FakeWriter()
+        val engine = CRPSyncEngine(w)
+        engine.setMeasurementSettings(
+            MeasurementSettings(
+                hrEnabled = true, hrIntervalMinutes = 10,
+                spo2Enabled = false, stressEnabled = false, hrvEnabled = true, temperatureEnabled = false,
+            ),
+        )
+        engine.runStartup()
+        val opcodes = w.opcodes()
+        // Every monitor is addressed on connect (enable or disable), never skipped.
+        for (op in timingEnables) assertTrue("missing monitor op $op", opcodes.contains(op))
+        // HR (interval 10) and HRV are enabled; SpO2/stress/temp are disabled (payload byte 0).
+        fun payloadOf(group: Int, cmd: Int) = w.sent.first { it[4].toInt() == group && it[5].toInt() == cmd }[6].toInt()
+        assertEquals(10, payloadOf(1, 6))   // HR enabled at the saved interval
+        assertEquals(0, payloadOf(1, 8))    // SpO2 disabled
+        assertEquals(0, payloadOf(1, 39))   // stress disabled
+        assertEquals(0, payloadOf(1, 13))   // temp disabled
     }
 
     @Test


### PR DESCRIPTION
## Summary
Fixes the two things blocking Colmi R11 (CRP firmware) all-day data in #29.

**All-day monitoring was never enabled.** A fresh R11 ships with every background monitor (HR/SpO₂/HRV/stress/temperature) turned OFF, and unlike QRing/YCBT it exposes no way to read its own config back — so the app never turned them on. The ring recorded nothing, and every history query came back empty. `CRPSyncEngine.runStartup` now falls back to `MeasurementSettings.ALL_ON_DEFAULT` until the user saves their own config (matching how `ColmiSyncEngine` force-enables on connect), and a shared `applyTimingSettings` sends explicit disables so a reconnect can't leave a monitor the user turned off still running.

**Sleep history now decodes** (group 2 / cmd 14). It was already being recorded — we just weren't parsing it. Faithful port of the vendor `e1/j.b` parser: `[dayIndex]` followed by 3-byte `[state, hour, minute]` records, each state running until the next record's timestamp (0=awake, 1=light, 2=deep, 3=rem), requiring `length % 3 == 1`. Emitted as a `SleepTimeline` with a per-minute stage list, wake-day anchored the same way `ColmiDecoder.decodeSleep` does.

## Verification
- Sleep decode validated against a real hardware capture from #29: a 26-record `dayIndex 0` reply decodes to a clean 01:07→08:05 night — **245 light / 110 deep / 63 REM** minutes.
- `TZ=UTC ./gradlew --no-daemon testDebugUnitTest` — full suite green (new tests in `CRPDecoderTest` / `CRPSyncEngineTest`).
- `./gradlew --no-daemon :app:assembleDebug` compiles.

## Still open (needs a fresh capture from this build)
- Group-7 vital histories (HR/SpO₂/HRV/stress) still land as acks — they need a full-day capture *with monitoring on* to reveal non-empty replies before decoding.
- Firmware still shows `?` (the version query returns an empty reply) — separate follow-up.
- Manual SpO₂/HRV/stress/temp round-trips want a "press Measure" capture to confirm.
