### PR TITLE
fix(crp): decode R11 wear state, fast-fail not-worn measures; bigger diag buffer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,16 +21,23 @@ jobs:
       - name: Parse version from tag
         id: ver
         run: |
-          TAG="${GITHUB_REF_NAME}"            # e.g. v1.0.0+5
+          TAG="${GITHUB_REF_NAME}"            # e.g. v1.0.0+5 or v1.0.0+5-rc1 (prerelease)
           NAME="${TAG#v}"; NAME="${NAME%%+*}" # 1.0.0
-          CODE="${TAG##*+}"                   # 5
+          CODE="${TAG##*+}"                   # 5 or 5-rc1
+          # A '-suffix' on the versionCode marks a prerelease test build (e.g. v1.0.0+26-rc1).
+          # The GitHub release is flagged prerelease, which the in-app updater never serves (it
+          # reads /releases/latest and skips prereleases), so it can go to a single tester
+          # without shipping to everyone. The suffix is stripped from the built versionCode.
+          PRERELEASE=false
+          if [[ "$CODE" == *-* ]]; then PRERELEASE=true; CODE="${CODE%%-*}"; fi
           if ! [[ "$CODE" =~ ^[0-9]+$ ]]; then
-            echo "::error::Tag must be v<versionName>+<versionCode>, e.g. v1.0.0+5 (got '$TAG')"
+            echo "::error::Tag must be v<versionName>+<versionCode>[-suffix], e.g. v1.0.0+5 or v1.0.0+5-rc1 (got '$TAG')"
             exit 1
           fi
           echo "name=$NAME" >> "$GITHUB_OUTPUT"
           echo "code=$CODE" >> "$GITHUB_OUTPUT"
-          echo "Building versionName=$NAME versionCode=$CODE"
+          echo "prerelease=$PRERELEASE" >> "$GITHUB_OUTPUT"
+          echo "Building versionName=$NAME versionCode=$CODE prerelease=$PRERELEASE"
 
       - uses: actions/setup-java@v4
         with:
@@ -90,5 +97,6 @@ jobs:
         with:
           tag_name: ${{ github.ref_name }}
           name: PulseLoop ${{ steps.ver.outputs.name }} (${{ steps.ver.outputs.code }})
+          prerelease: ${{ steps.ver.outputs.prerelease }}
           generate_release_notes: true
           files: dist/*.apk

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,13 +71,26 @@ supporting evidence as the cause.
 - The single-channel contention theory is **plausible but unproven** — no capture has shown a spot
   measure starved by an active history dump. Don't treat it as established; if you suspect it, prove
   it from a capture where the channel is actually saturated during a failed measure.
-- **Vendor divergences to fix when the group-7 all-day history is tackled** (verified from the
-  decompile, separate from the wear-state issue): the vendor *can* read monitor state
-  (`queryTimingHeartRateState`), so the engine's "no read-back → force `ALL_ON_DEFAULT` every connect"
-  premise is false — match the vendor (query state / apply saved config). The all-day HR history is
-  `queryHistoryTimingHeartRate(day)`, **not** the paramless `queryHistoryHeartRate()` (group-7 cmd 4)
-  we currently send — likely why group-7 comes back empty. And the vendor sends spot measures on a
-  priority path (`insertNotificationMessage`) distinct from config/history (`insertBleMessage`).
+- **All-day "timing" vital history is DECODED (build 27, rc3), confirmed against zaggash's rc2
+  capture.** Layout (vendor `e1/{f,d,g,l}.java`, group 2): a query `[day, frameIndex]` returns
+  `[day][frameIndex][slots…]`, one **5-minute** slot per sample (`w0.b.a()/5`), `0` = no reading.
+  **HR (cmd 15) / SpO2 (17) / stress (47)** are **one byte/slot**, 144 slots/frame, terminal frame
+  index **1** (two frames = 288 slots = 24 h). **HRV (cmd 16)** is a **little-endian 2-byte** value
+  per slot, 72 slots/frame, terminal index **3** (four frames). Clamps: HR 40..200, SpO2 ≤100, HRV
+  any positive, stress 1..100. Each slot's time = `localMidnight(today − day) + globalSlot*5min`
+  (ring stamps against **local** midnight — a UTC-vs-local offset makes samples look "in the future"
+  in a raw capture; that's expected, not a bug). `CRPDecoder.decodeTimingHistory` emits one
+  `HistoryMeasurement` per valid slot (persisted idempotently, `source="history"`) plus a
+  `TimingHistoryFrame` marker that drives `CRPSyncEngine.handle` to pull the next frame — the
+  vendor's sequential `insertBleMessage(<query>.b(day, index+1))`. **Still to hardware-validate on
+  rc3:** that the ring answers a direct `[day, index>0]` request (the multi-frame follow-up). In
+  the rc2 capture SpO2 came back all-zero and stress didn't reply at all — confirm those all-day
+  monitors are actually enabled on his ring before assuming a decode gap.
+- **Vendor divergences still open** (verified from the decompile): the vendor *can* read monitor
+  state (`queryTimingHeartRateState`), so the engine's "no read-back → force `ALL_ON_DEFAULT` every
+  connect" premise is false — match the vendor (query state / apply saved config). And the vendor
+  sends spot measures on a priority path (`insertNotificationMessage`) distinct from config/history
+  (`insertBleMessage`).
 - Whenever you touch CRP measure/sync/all-day behavior, hardware-validate with the ring owner
   (zaggash) — and for a "measure broken" report, first get a capture of **several** Measure presses
   with the ring snug and still, to separate a contact failure from a real code bug.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,3 +38,46 @@ the condition to "whenever `supportBlePair` is set" to match the vendor app — 
 the change that caused the regression, and it will cause it again for the R10.
 
 See `docs/qring-ble-adoption.md` §5a for the full history and the decompiled source references.
+
+## Colmi R11 (CRP "Da Rings") — diagnose from the capture, and decode wear state before blaming code
+
+**Read this before changing anything in `CRP*` startup, sync, all-day-monitoring, or history code —
+and before assuming a "Measure button broken" report is a code regression. Issue #29, 2026-07-22:
+a reported HR-measure regression after enabling all-day monitoring (`c4d61ca`) turned out, on
+capture analysis, to most likely be a wear/contact failure — not the code change.**
+
+**How the mis-diagnosis happened (don't repeat it):** the "HR stopped working after build 25"
+report *looked* like the all-day-monitoring commit broke it, and a plausible "single-channel
+starvation" story was constructed (the R11 does funnel handshake + timing config + `queryAllHistory`
++ on-demand measures through one `fdd2`-write/`fdd3`-notify path). But the capture contradicted it:
+during the failed 30 s measure the channel was **idle ~18 s**, the sleep "dump" was 2 frames, and the
+ring simply returned no `g1/cmd9` result. The decisive clue was two **`group 3 / cmd 7`** frames that
+appear only in the broken capture — which the vendor (`g1/a.java`) decodes as
+**`onWearStateChange(bArr[0] > 0)`**, i.e. on-finger / skin-contact detection. `g3c7 [00]` = **ring not
+worn**. An optical sensor with no skin contact cannot read HR/SpO₂. This matched the user's own
+"it says keep your hand still" and hedged "I feel like I lost HR." The all-day change had no
+supporting evidence as the cause.
+
+**Rules / lessons:**
+- **Diagnose R11 issues from the rawPackets capture, not from "what changed."** Decode the actual
+  `group/cmd` frames against the vendor `g1/a.java` response dispatch before attributing a symptom to
+  a recent commit. A known-good "measure button" capture (worn, HR returns ~19 s after `g1/cmd9 [01]`)
+  is the baseline to diff against.
+- **Wear state = `group 3 / cmd 7`** (`onWearStateChange`, `payload[0] > 0`). Decoded as of the
+  wear-state fix: `CRPDecoder` → `RingDecodedEvent.WearingStatus` → `PulseEvent.WearState`, and
+  `RingSyncCoordinator` fast-fails an in-flight CRP spot measure (with a "put the ring on" message)
+  when it reports not-worn *before* any reading. Gated to CRP — YCBT's wear polarity is unverified.
+  A not-worn measure now fails in ~2 s with guidance instead of spinning the full window silently.
+- The single-channel contention theory is **plausible but unproven** — no capture has shown a spot
+  measure starved by an active history dump. Don't treat it as established; if you suspect it, prove
+  it from a capture where the channel is actually saturated during a failed measure.
+- **Vendor divergences to fix when the group-7 all-day history is tackled** (verified from the
+  decompile, separate from the wear-state issue): the vendor *can* read monitor state
+  (`queryTimingHeartRateState`), so the engine's "no read-back → force `ALL_ON_DEFAULT` every connect"
+  premise is false — match the vendor (query state / apply saved config). The all-day HR history is
+  `queryHistoryTimingHeartRate(day)`, **not** the paramless `queryHistoryHeartRate()` (group-7 cmd 4)
+  we currently send — likely why group-7 comes back empty. And the vendor sends spot measures on a
+  priority path (`insertNotificationMessage`) distinct from config/history (`insertBleMessage`).
+- Whenever you touch CRP measure/sync/all-day behavior, hardware-validate with the ring owner
+  (zaggash) — and for a "measure broken" report, first get a capture of **several** Measure presses
+  with the ring snug and still, to separate a contact failure from a real code bug.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -19,7 +19,7 @@ android {
         // versionCode/versionName are overridable from Gradle properties so the release CI
         // can drive them straight from the git tag (e.g. -PappVersionCode=5 -PappVersionName=1.0.0).
         // Local builds fall back to the literals below.
-        versionCode = (project.findProperty("appVersionCode") as String?)?.toIntOrNull() ?: 25
+        versionCode = (project.findProperty("appVersionCode") as String?)?.toIntOrNull() ?: 26
         versionName = (project.findProperty("appVersionName") as String?) ?: "1.0.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -19,7 +19,7 @@ android {
         // versionCode/versionName are overridable from Gradle properties so the release CI
         // can drive them straight from the git tag (e.g. -PappVersionCode=5 -PappVersionName=1.0.0).
         // Local builds fall back to the literals below.
-        versionCode = (project.findProperty("appVersionCode") as String?)?.toIntOrNull() ?: 26
+        versionCode = (project.findProperty("appVersionCode") as String?)?.toIntOrNull() ?: 27
         versionName = (project.findProperty("appVersionName") as String?) ?: "1.0.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/java/com/pulseloop/diagnostics/DiagnosticsExporter.kt
+++ b/app/src/main/java/com/pulseloop/diagnostics/DiagnosticsExporter.kt
@@ -78,7 +78,10 @@ object DiagnosticsExporter {
             // Raw BLE packets for protocol debugging. When masking, health-measurement frames
             // are reduced to their opcode (the values live in the payload); control frames stay
             // whole so connection/pairing flow is still fully visible.
-            val packets = db.rawPacketDao().recent(200)
+            // 1000 (was 200): high-frequency steps/activity pushes flood the buffer, so a small
+            // window evicts the command-channel frames a capture is actually taken for — e.g. the
+            // spot-measure round-trip or a multi-frame history reply (issue #29 debugging).
+            val packets = db.rawPacketDao().recent(1000)
             putJsonArray("rawPackets") {
                 packets.forEach { pkt ->
                     val kind = pkt.decodedKind ?: ""

--- a/app/src/main/java/com/pulseloop/ring/CRPDecoder.kt
+++ b/app/src/main/java/com/pulseloop/ring/CRPDecoder.kt
@@ -104,13 +104,16 @@ object CRPDecoder {
             return decodeHistoryOrDeviceInfoResponse(cmd, payload, now)
         }
 
-        // Group 2: sleep + temperature history (decompiled `b1/e0.c`/`e0.d`). Sleep is confirmed
-        // against a hardware capture (zaggash's R11, issue #29); temp history stays an ack until a
-        // non-empty capture pins the layout.
+        // Group 2: sleep + the all-day "timing" vital timelines + temperature history.
+        //   cmd 14        → sleep (decompiled `e1/j`), confirmed against a hardware capture.
+        //   cmd 15/16/17/47 → HR/HRV/SpO2/stress all-day timeline (decompiled `e1/{f,g,d,l}`),
+        //                     confirmed against zaggash's R11 rc2 capture (issue #29).
+        //   cmd 48        → temperature history, still an ack until a non-empty capture pins it.
         if (group == CRPCommands.GROUP_HISTORY) {
             if (cmd == CRPCommands.CMD_QUERY_HISTORY_SLEEP) {
                 return decodeSleep(payload, now, zone)
             }
+            decodeTimingHistory(cmd, payload, now, zone)?.let { return it }
             return listOf(RingDecodedEvent.CommandAck(commandId = ((group shl 4) or (cmd and 0x0F)).toUByte()))
         }
 
@@ -175,6 +178,73 @@ object CRPDecoder {
      */
     private fun decodeHistoryOrDeviceInfoResponse(cmd: Int, payload: ByteArray, now: Instant): List<RingDecodedEvent> {
         return listOf(RingDecodedEvent.CommandAck(commandId = ((CRPCommands.GROUP_DEVICE_INFO shl 4) or (cmd and 0x0F)).toUByte()))
+    }
+
+    /** All-day timeline frames carry 144 sample-slots at a fixed 5-minute cadence (`w0.b.a() / 5`
+     *  in the vendor). Two slot widths: HR/SpO2/stress store one byte per slot (144 slots/frame,
+     *  terminal frame index 1); HRV stores a little-endian 2-byte value per slot (72 slots/frame,
+     *  terminal index 3). Both reassemble to a 288-slot (24 h) day across their frames. */
+    private const val TIMING_SLOT_MINUTES = 5
+    private const val TIMING_SLOTS_PER_FRAME_1BYTE = 144
+    private const val TIMING_SLOTS_PER_FRAME_2BYTE = 72
+
+    /**
+     * Decode a CRP all-day "timing" vital-history reply (group 2). Returns null for a non-timing
+     * group-2 cmd (e.g. temp cmd 48) so the caller falls back to an ack. Layout, confirmed against
+     * zaggash's R11 rc2 capture and the vendor parsers `e1/{f,g,d,l}.java`:
+     *   `[day][frameIndex][slot samples…]` — one 5-minute slot per sample, `0` = no reading.
+     * HR/SpO2/stress use one byte per slot; HRV uses a little-endian 2-byte value per slot. Each
+     * slot's absolute time is `localMidnight(today − day) + (frameIndex*slotsPerFrame + slot)*5min`,
+     * matching the vendor's `w0.b.a()/5` slot indexing. Emits a [RingDecodedEvent.HistoryMeasurement]
+     * per valid slot (invalid/zero slots dropped, per the vendor's per-vital clamp) plus a trailing
+     * [RingDecodedEvent.TimingHistoryFrame] that drives the engine's next-frame follow-up.
+     */
+    private fun decodeTimingHistory(cmd: Int, payload: ByteArray, now: Instant, zone: ZoneId): List<RingDecodedEvent>? {
+        // (kind, sample byte-width, validity predicate) per vital. Ranges mirror the vendor clamps:
+        // HR 40..200 (`e1/f.e`), SpO2 1..100 (`e1/d.e`, >100→0), HRV any positive (`e1/g.d`, no clamp),
+        // stress 1..100 (`e1/l.d`, no clamp; 0 treated as no-reading). Zero is always "no sample".
+        val kind: MeasurementKind
+        val twoByte: Boolean
+        val valid: (Int) -> Boolean
+        when (cmd) {
+            CRPCommands.CMD_QUERY_TIMING_HR -> { kind = MeasurementKind.HEART_RATE; twoByte = false; valid = { it in 40..200 } }
+            CRPCommands.CMD_QUERY_TIMING_SPO2 -> { kind = MeasurementKind.SPO2; twoByte = false; valid = { it in 1..100 } }
+            CRPCommands.CMD_QUERY_TIMING_HRV -> { kind = MeasurementKind.HRV; twoByte = true; valid = { it in 1..300 } }
+            CRPCommands.CMD_QUERY_TIMING_STRESS -> { kind = MeasurementKind.STRESS; twoByte = false; valid = { it in 1..100 } }
+            else -> return null
+        }
+        // [day][frameIndex] header; anything shorter is malformed.
+        if (payload.size < 2) return emptyList()
+        val day = payload[0].toInt() and 0xFF
+        val frameIndex = payload[1].toInt() and 0xFF
+        // A wilder day than CRPHistoryDay allows is a corrupt reply — ack without inventing samples.
+        if (day > MAX_HISTORY_DAY) {
+            return listOf(RingDecodedEvent.CommandAck(commandId = ((CRPCommands.GROUP_HISTORY shl 4) or (cmd and 0x0F)).toUByte()))
+        }
+
+        val midnight = now.atZone(zone).toLocalDate().minusDays(day.toLong()).atStartOfDay(zone).toInstant()
+        val slotsPerFrame = if (twoByte) TIMING_SLOTS_PER_FRAME_2BYTE else TIMING_SLOTS_PER_FRAME_1BYTE
+        val events = mutableListOf<RingDecodedEvent>()
+        val step = if (twoByte) 2 else 1
+        var slot = 0
+        var i = 2
+        while (i + step - 1 < payload.size) {
+            val value = if (twoByte) {
+                (payload[i].toInt() and 0xFF) or ((payload[i + 1].toInt() and 0xFF) shl 8)
+            } else {
+                payload[i].toInt() and 0xFF
+            }
+            if (valid(value)) {
+                val globalSlot = frameIndex * slotsPerFrame + slot
+                val ts = midnight.plusSeconds(globalSlot.toLong() * TIMING_SLOT_MINUTES * 60)
+                events.add(RingDecodedEvent.HistoryMeasurement(kind, value.toDouble(), ts))
+            }
+            i += step
+            slot++
+        }
+        // Drive the vendor's sequential next-frame pull (see [RingDecodedEvent.TimingHistoryFrame]).
+        events.add(RingDecodedEvent.TimingHistoryFrame(cmd = cmd, day = day, frameIndex = frameIndex))
+        return events
     }
 
     /**

--- a/app/src/main/java/com/pulseloop/ring/CRPDecoder.kt
+++ b/app/src/main/java/com/pulseloop/ring/CRPDecoder.kt
@@ -114,6 +114,16 @@ object CRPDecoder {
             return listOf(RingDecodedEvent.CommandAck(commandId = ((group shl 4) or (cmd and 0x0F)).toUByte()))
         }
 
+        // Group 3: power control + the autonomous wear-state push (vendor `g1/a.java` case 3→7,
+        // `onWearStateChange(payload[0] > 0)`). Confirmed against zaggash's R11 (issue #29): a spot
+        // measure returns nothing while `payload[0] == 0` (ring off the finger).
+        if (group == CRPCommands.GROUP_POWER) {
+            if (cmd == CRPCommands.CMD_WEAR_STATE && payload.isNotEmpty()) {
+                return listOf(RingDecodedEvent.WearingStatus(worn = (payload[0].toInt() and 0xFF) != 0, _timestamp = now))
+            }
+            return listOf(RingDecodedEvent.CommandAck(commandId = ((group shl 4) or (cmd and 0x0F)).toUByte()))
+        }
+
         // Unknown group/cmd — ack.
         return listOf(RingDecodedEvent.CommandAck(commandId = ((group shl 4) or (cmd and 0x0F)).toUByte()))
     }

--- a/app/src/main/java/com/pulseloop/ring/CRPProtocol.kt
+++ b/app/src/main/java/com/pulseloop/ring/CRPProtocol.kt
@@ -97,10 +97,14 @@ object CRPCommands {
     const val CMD_QUERY_HISTORY_SLEEP = 14    // b1/e0.c: q.c(2,14, [CRPHistoryDay])
     const val CMD_QUERY_HISTORY_TEMP = 48     // b1/e0.d: q.b(2,48)
 
-    // Group 3 — power control.
+    // Group 3 — power control + device-state pushes.
     const val GROUP_POWER = 3
     const val CMD_FACTORY_RESET = 0     // b1/l.v: q.b(3,0)
     const val CMD_RESTART = 1           // b1/l.w: q.b(3,1)
+    // Autonomous wear-state push: vendor `g1/a.java` case 3→7 → onWearStateChange(payload[0] > 0).
+    // payload[0] == 0 ⇒ ring not on finger / no skin contact (issue #29: an optical spot measure
+    // returns nothing while this is 0; we surface it instead of spinning the full window).
+    const val CMD_WEAR_STATE = 7
 
     // Group 9 — device actions.
     const val GROUP_ACTION = 9

--- a/app/src/main/java/com/pulseloop/ring/CRPProtocol.kt
+++ b/app/src/main/java/com/pulseloop/ring/CRPProtocol.kt
@@ -87,15 +87,19 @@ object CRPCommands {
     const val CMD_QUERY_DEVICE_INFO = 0       // b1/r.a: q.b(7,0)
     const val CMD_QUERY_FIRMWARE_VERSION = 1  // b1/r.b: q.b(7,1)
     const val CMD_QUERY_DEVICE_SN = 13        // b1/r.c: q.b(7,13)
-    const val CMD_QUERY_HISTORY_HR = 4        // b1/e0.a: q.b(7,4)
-    const val CMD_QUERY_HISTORY_STRESS = 5    // b1/e0.b: q.c(7,5, [interval])
-    const val CMD_QUERY_HISTORY_HRV = 6       // b1/e0.e: q.c(7,6, [interval])
-    const val CMD_QUERY_HISTORY_SPO2 = 7      // b1/e0.f: q.b(7,7)
 
-    // Group 2 — the two history queries that live outside group 7 (decompiled b1/e0).
+    // Group 2 — the day's stored vital timelines. The all-day "timing" histories the vendor's sync
+    // pass actually pulls (`u3/g1.java`) live here with a [day, 0] payload, NOT on group 7: the ring
+    // returned empty for the old group-7 HR/SpO2/HRV/stress queries (issue #29). Replies are
+    // multi-frame (`e1/f.i` reassembles by index into a CRPHeartRateInfo: startTime + list + interval).
     const val GROUP_HISTORY = 2
     const val CMD_QUERY_HISTORY_SLEEP = 14    // b1/e0.c: q.c(2,14, [CRPHistoryDay])
+    const val CMD_QUERY_TIMING_HR = 15        // b1/t.b:  q.c(2,15, [day, 0])
+    const val CMD_QUERY_TIMING_HRV = 16       // b1/u.b:  q.c(2,16, [day, 0])
+    const val CMD_QUERY_TIMING_SPO2 = 17      // b1/h.b:  q.c(2,17, [day, 0])
+    const val CMD_QUERY_TIMING_STRESS = 47    // b1/h0.b: q.c(2,47, [day, 0])
     const val CMD_QUERY_HISTORY_TEMP = 48     // b1/e0.d: q.b(2,48)
+    const val HISTORY_DAY_TODAY = 0           // CRPHistoryDay.TODAY; YESTERDAY = 1
 
     // Group 3 — power control + device-state pushes.
     const val GROUP_POWER = 3
@@ -237,26 +241,27 @@ object CRPProtocol {
     fun disableTimingTemp(): ByteArray =
         frame(CRPCommands.GROUP_DEVICE, CRPCommands.CMD_ENABLE_TIMING_TEMP, byteArrayOf(0))
 
-    // ---- History query commands ----
-    // Most vitals are group 7 (b1/e0.a/b/e/f); sleep and temp are group 2 (b1/e0.c/d).
+    // ---- History query commands (all group 2; see GROUP_HISTORY) ----
+    // The all-day vital timelines take a [day, 0] payload (vendor `b1/{t,u,h,h0}.b`); sleep takes
+    // [day]; temp takes none. `day` is CRPHistoryDay (0 = today).
 
-    fun queryHistoryHeartRate(): ByteArray =
-        frame(CRPCommands.GROUP_DEVICE_INFO, CRPCommands.CMD_QUERY_HISTORY_HR)
+    fun queryTimingHeartRateHistory(day: Int = CRPCommands.HISTORY_DAY_TODAY): ByteArray =
+        frame(CRPCommands.GROUP_HISTORY, CRPCommands.CMD_QUERY_TIMING_HR, byteArrayOf(day.toByte(), 0))
 
-    fun queryHistoryStress(): ByteArray =
-        frame(CRPCommands.GROUP_DEVICE_INFO, CRPCommands.CMD_QUERY_HISTORY_STRESS)
+    fun queryTimingHrvHistory(day: Int = CRPCommands.HISTORY_DAY_TODAY): ByteArray =
+        frame(CRPCommands.GROUP_HISTORY, CRPCommands.CMD_QUERY_TIMING_HRV, byteArrayOf(day.toByte(), 0))
+
+    fun queryTimingSpO2History(day: Int = CRPCommands.HISTORY_DAY_TODAY): ByteArray =
+        frame(CRPCommands.GROUP_HISTORY, CRPCommands.CMD_QUERY_TIMING_SPO2, byteArrayOf(day.toByte(), 0))
+
+    fun queryTimingStressHistory(day: Int = CRPCommands.HISTORY_DAY_TODAY): ByteArray =
+        frame(CRPCommands.GROUP_HISTORY, CRPCommands.CMD_QUERY_TIMING_STRESS, byteArrayOf(day.toByte(), 0))
 
     fun queryHistorySleep(daysAgo: Int = 0): ByteArray =
         frame(CRPCommands.GROUP_HISTORY, CRPCommands.CMD_QUERY_HISTORY_SLEEP, byteArrayOf(daysAgo.toByte()))
 
     fun queryHistoryTemp(): ByteArray =
         frame(CRPCommands.GROUP_HISTORY, CRPCommands.CMD_QUERY_HISTORY_TEMP)
-
-    fun queryHistoryHRV(): ByteArray =
-        frame(CRPCommands.GROUP_DEVICE_INFO, CRPCommands.CMD_QUERY_HISTORY_HRV)
-
-    fun queryHistorySpO2(): ByteArray =
-        frame(CRPCommands.GROUP_DEVICE_INFO, CRPCommands.CMD_QUERY_HISTORY_SPO2)
 
     // ---- Device info queries (group 7) ----
 

--- a/app/src/main/java/com/pulseloop/ring/CRPProtocol.kt
+++ b/app/src/main/java/com/pulseloop/ring/CRPProtocol.kt
@@ -242,20 +242,24 @@ object CRPProtocol {
         frame(CRPCommands.GROUP_DEVICE, CRPCommands.CMD_ENABLE_TIMING_TEMP, byteArrayOf(0))
 
     // ---- History query commands (all group 2; see GROUP_HISTORY) ----
-    // The all-day vital timelines take a [day, 0] payload (vendor `b1/{t,u,h,h0}.b`); sleep takes
-    // [day]; temp takes none. `day` is CRPHistoryDay (0 = today).
+    // The all-day vital timelines take a [day, frameIndex] payload (vendor `b1/{t,u,h,h0}.b`); sleep
+    // takes [day]; temp takes none. `day` is CRPHistoryDay (0 = today). A day's 5-minute timeline is
+    // split across several 144-slot frames selected by `frameIndex`: the vendor requests index 0,
+    // then pulls the next index on each reply until the terminal frame (HR/SpO2/stress → index 1,
+    // HRV → index 3), reassembling a full 288-slot (24 h × 5-min) day. See `e1/{f,d,g,l}.java` and
+    // [CRPSyncEngine]'s follow-up on [RingDecodedEvent.TimingHistoryFrame].
 
-    fun queryTimingHeartRateHistory(day: Int = CRPCommands.HISTORY_DAY_TODAY): ByteArray =
-        frame(CRPCommands.GROUP_HISTORY, CRPCommands.CMD_QUERY_TIMING_HR, byteArrayOf(day.toByte(), 0))
+    fun queryTimingHeartRateHistory(day: Int = CRPCommands.HISTORY_DAY_TODAY, frameIndex: Int = 0): ByteArray =
+        frame(CRPCommands.GROUP_HISTORY, CRPCommands.CMD_QUERY_TIMING_HR, byteArrayOf(day.toByte(), frameIndex.toByte()))
 
-    fun queryTimingHrvHistory(day: Int = CRPCommands.HISTORY_DAY_TODAY): ByteArray =
-        frame(CRPCommands.GROUP_HISTORY, CRPCommands.CMD_QUERY_TIMING_HRV, byteArrayOf(day.toByte(), 0))
+    fun queryTimingHrvHistory(day: Int = CRPCommands.HISTORY_DAY_TODAY, frameIndex: Int = 0): ByteArray =
+        frame(CRPCommands.GROUP_HISTORY, CRPCommands.CMD_QUERY_TIMING_HRV, byteArrayOf(day.toByte(), frameIndex.toByte()))
 
-    fun queryTimingSpO2History(day: Int = CRPCommands.HISTORY_DAY_TODAY): ByteArray =
-        frame(CRPCommands.GROUP_HISTORY, CRPCommands.CMD_QUERY_TIMING_SPO2, byteArrayOf(day.toByte(), 0))
+    fun queryTimingSpO2History(day: Int = CRPCommands.HISTORY_DAY_TODAY, frameIndex: Int = 0): ByteArray =
+        frame(CRPCommands.GROUP_HISTORY, CRPCommands.CMD_QUERY_TIMING_SPO2, byteArrayOf(day.toByte(), frameIndex.toByte()))
 
-    fun queryTimingStressHistory(day: Int = CRPCommands.HISTORY_DAY_TODAY): ByteArray =
-        frame(CRPCommands.GROUP_HISTORY, CRPCommands.CMD_QUERY_TIMING_STRESS, byteArrayOf(day.toByte(), 0))
+    fun queryTimingStressHistory(day: Int = CRPCommands.HISTORY_DAY_TODAY, frameIndex: Int = 0): ByteArray =
+        frame(CRPCommands.GROUP_HISTORY, CRPCommands.CMD_QUERY_TIMING_STRESS, byteArrayOf(day.toByte(), frameIndex.toByte()))
 
     fun queryHistorySleep(daysAgo: Int = 0): ByteArray =
         frame(CRPCommands.GROUP_HISTORY, CRPCommands.CMD_QUERY_HISTORY_SLEEP, byteArrayOf(daysAgo.toByte()))

--- a/app/src/main/java/com/pulseloop/ring/CRPSyncEngine.kt
+++ b/app/src/main/java/com/pulseloop/ring/CRPSyncEngine.kt
@@ -11,9 +11,9 @@ package com.pulseloop.ring
  * arrive as autonomous pushes/reads (see [CRPDriver]). HRV / stress / temperature are all-day
  * metrics — their timing is enabled here and live results decode via [CRPDecoder]. Of the stored
  * day timelines, sleep (group-2/cmd-14) is decoded ([CRPDecoder.decodeSleep], confirmed against a
- * hardware capture). The group-2 all-day "timing" vital histories (HR/SpO2/HRV/stress) are now
- * queried with the correct opcodes so the ring returns them; decoding those multi-frame replies
- * into samples is the next step, done against a real capture rather than a blind port.
+ * hardware capture), and the group-2 all-day "timing" vital histories (HR/SpO2/HRV/stress) decode
+ * into [RingDecodedEvent.HistoryMeasurement] samples (confirmed against zaggash's R11 rc2 capture);
+ * their multi-frame replies reassemble via the next-frame follow-up in [handle].
  */
 class CRPSyncEngine(private val writer: RingCommandWriter?) : RingSyncEngine {
 
@@ -45,22 +45,28 @@ class CRPSyncEngine(private val writer: RingCommandWriter?) : RingSyncEngine {
         applyTimingSettings(measurementSettings ?: MeasurementSettings.ALL_ON_DEFAULT)
         // Pull the day's stored all-day timeline. runStartup() IS the poll pass (RingSyncWorker's
         // ~30-min background sync and the foreground syncNow() both re-invoke it), so this runs at
-        // the app's configured polling cadence; the ring samples at hrIntervalMinutes (above).
-        // The ring only emits history replies once asked — so this also produces the group-7/2
-        // reply frames in a diagnostic capture, which is what we need to finish decoding them.
-        // NOTE: the replies are currently acknowledged, not yet parsed into samples
-        // (CRPDecoder.decodeHistoryOrDeviceInfoResponse is a TODO pending that capture).
+        // the app's configured polling cadence; the ring samples at hrIntervalMinutes (above). The
+        // ring only emits history replies once asked; CRPDecoder parses the group-2 timing frames
+        // into HistoryMeasurement samples (confirmed against zaggash's R11 rc2 capture) and this
+        // engine walks the remaining frames of each day via the follow-up in handle().
         queryAllHistory()
     }
 
-    /** Request the stored all-day timelines the ring has accumulated (group 7 for HR/stress/HRV/
-     *  SpO2, group 2 for sleep/temp). Vendor `u3/g1.java` fires the same set on its sync pass. */
+    /** Frame follow-ups already requested this poll pass, keyed `cmd * 100 + frameIndex`, so a ring
+     *  that re-sends the same frame can't trigger a request storm. Cleared at the start of every
+     *  [queryAllHistory] pass so each sync re-pulls the full timeline. */
+    private val requestedTimingFrames = mutableSetOf<Int>()
+
+    /** Request the stored all-day timelines the ring has accumulated: the group-2 "timing" vital
+     *  timelines (HR/SpO2/HRV/stress), temperature, and sleep. Vendor `u3/g1.java` fires the same set
+     *  on its sync pass. Each timing query pulls frame 0; the ring's reply drives [handle] to pull
+     *  the next frame until the day is complete. */
     private fun queryAllHistory() {
-        // The all-day vital timelines the vendor's sync pass pulls (`u3/g1.java`): the group-2
-        // "timing" histories for TODAY. The previous group-7 HR/SpO2/HRV/stress queries were the
-        // wrong opcodes (device-info group) and the ring returned empty every time (issue #29).
-        // Replies are multi-frame; decoding them into samples is the next step, done against a real
-        // capture now that the ring actually answers (CRPDecoder acks them for now — never blind).
+        requestedTimingFrames.clear()
+        // The group-2 "timing" histories for TODAY, frame 0. The previous group-7 HR/SpO2/HRV/stress
+        // queries were the wrong opcodes (device-info group) and the ring returned empty every time
+        // (issue #29). Confirmed decoding into samples against zaggash's R11 rc2 capture; the
+        // multi-frame replies reassemble via the next-frame follow-up in [handle].
         send(CRPProtocol.queryTimingHeartRateHistory())
         send(CRPProtocol.queryTimingSpO2History())
         send(CRPProtocol.queryTimingHrvHistory())
@@ -69,9 +75,34 @@ class CRPSyncEngine(private val writer: RingCommandWriter?) : RingSyncEngine {
         send(CRPProtocol.queryHistorySleep())
     }
 
+    /** The last frame index each timing vital emits before its day is complete (vendor terminal
+     *  index: HR/SpO2/stress finalize at frame 1 — two 144-slot frames; HRV at frame 3 — four
+     *  72-slot frames). A reply below this index triggers a pull of the next frame. */
+    private fun terminalFrameIndex(cmd: Int): Int =
+        if (cmd == CRPCommands.CMD_QUERY_TIMING_HRV) 3 else 1
+
+    /** Build the next-frame query for a timing vital, or null for a non-timing cmd. */
+    private fun timingQuery(cmd: Int, day: Int, frameIndex: Int): ByteArray? = when (cmd) {
+        CRPCommands.CMD_QUERY_TIMING_HR -> CRPProtocol.queryTimingHeartRateHistory(day, frameIndex)
+        CRPCommands.CMD_QUERY_TIMING_HRV -> CRPProtocol.queryTimingHrvHistory(day, frameIndex)
+        CRPCommands.CMD_QUERY_TIMING_SPO2 -> CRPProtocol.queryTimingSpO2History(day, frameIndex)
+        CRPCommands.CMD_QUERY_TIMING_STRESS -> CRPProtocol.queryTimingStressHistory(day, frameIndex)
+        else -> null
+    }
+
     override fun handle(event: RingDecodedEvent) {
-        // Steps/HR/battery are persisted by RingBLEClient via RingEventBridge; v1 keeps no
-        // engine-side state (no staged history pipeline to advance).
+        // Steps/HR/battery are persisted by RingBLEClient via RingEventBridge. The one piece of
+        // engine-side state is the all-day timeline's multi-frame pull: on each timing-history frame
+        // the ring returns, request the next frame until the vital's terminal index — the vendor's
+        // sequential `insertBleMessage(<query>.b(day, index + 1))` (`e1/{f,d,g,l}.java`). The
+        // samples themselves are decoded + persisted via the bridge; this only advances the cursor.
+        if (event is RingDecodedEvent.TimingHistoryFrame) {
+            if (event.frameIndex >= terminalFrameIndex(event.cmd)) return
+            val nextIndex = event.frameIndex + 1
+            // Guard against a ring that re-sends the same frame spamming duplicate follow-ups.
+            if (!requestedTimingFrames.add(event.cmd * 100 + nextIndex)) return
+            send(timingQuery(event.cmd, event.day, nextIndex))
+        }
     }
 
     // ---- Spot (manual) measurements. Trigger via the fdda command channel; the ring replies on

--- a/app/src/main/java/com/pulseloop/ring/CRPSyncEngine.kt
+++ b/app/src/main/java/com/pulseloop/ring/CRPSyncEngine.kt
@@ -11,7 +11,9 @@ package com.pulseloop.ring
  * arrive as autonomous pushes/reads (see [CRPDriver]). HRV / stress / temperature are all-day
  * metrics — their timing is enabled here and live results decode via [CRPDecoder]. Of the stored
  * day timelines, sleep (group-2/cmd-14) is decoded ([CRPDecoder.decodeSleep], confirmed against a
- * hardware capture); the group-7 vital histories still land as acks pending a non-empty capture.
+ * hardware capture). The group-2 all-day "timing" vital histories (HR/SpO2/HRV/stress) are now
+ * queried with the correct opcodes so the ring returns them; decoding those multi-frame replies
+ * into samples is the next step, done against a real capture rather than a blind port.
  */
 class CRPSyncEngine(private val writer: RingCommandWriter?) : RingSyncEngine {
 
@@ -54,10 +56,15 @@ class CRPSyncEngine(private val writer: RingCommandWriter?) : RingSyncEngine {
     /** Request the stored all-day timelines the ring has accumulated (group 7 for HR/stress/HRV/
      *  SpO2, group 2 for sleep/temp). Vendor `u3/g1.java` fires the same set on its sync pass. */
     private fun queryAllHistory() {
-        send(CRPProtocol.queryHistoryHeartRate())
-        send(CRPProtocol.queryHistorySpO2())
-        send(CRPProtocol.queryHistoryHRV())
-        send(CRPProtocol.queryHistoryStress())
+        // The all-day vital timelines the vendor's sync pass pulls (`u3/g1.java`): the group-2
+        // "timing" histories for TODAY. The previous group-7 HR/SpO2/HRV/stress queries were the
+        // wrong opcodes (device-info group) and the ring returned empty every time (issue #29).
+        // Replies are multi-frame; decoding them into samples is the next step, done against a real
+        // capture now that the ring actually answers (CRPDecoder acks them for now — never blind).
+        send(CRPProtocol.queryTimingHeartRateHistory())
+        send(CRPProtocol.queryTimingSpO2History())
+        send(CRPProtocol.queryTimingHrvHistory())
+        send(CRPProtocol.queryTimingStressHistory())
         send(CRPProtocol.queryHistoryTemp())
         send(CRPProtocol.queryHistorySleep())
     }

--- a/app/src/main/java/com/pulseloop/ring/PulseEventBus.kt
+++ b/app/src/main/java/com/pulseloop/ring/PulseEventBus.kt
@@ -44,6 +44,9 @@ sealed class PulseEvent {
     data class SleepTimeline(val timestamp: java.time.Instant, val stages: List<SleepStage>) : PulseEvent()
     data class SyncProgress(val stage: String) : PulseEvent()
     data class FirmwareVersion(val version: Int?) : PulseEvent()
+    /** The ring's on-finger / skin-contact state changed. `worn == false` ⇒ an optical spot
+     *  measurement can't produce a reading, so the coordinator fast-fails it (issue #29). */
+    data class WearState(val worn: Boolean) : PulseEvent()
 }
 
 enum class RingConnectionState { IDLE, SCANNING, CONNECTING, CONNECTED, DISCONNECTED, RECONNECTING, FAILED }

--- a/app/src/main/java/com/pulseloop/ring/RingDecodedEvent.kt
+++ b/app/src/main/java/com/pulseloop/ring/RingDecodedEvent.kt
@@ -89,6 +89,7 @@ sealed class RingDecodedEvent {
         is SupportFunctions -> Instant.EPOCH
         is ChipScheme -> Instant.EPOCH
         is WearingStatus -> this._timestamp
+        is TimingHistoryFrame -> Instant.EPOCH
         is MeasurementRejected -> Instant.EPOCH
         is Unknown -> Instant.EPOCH
     }
@@ -176,6 +177,24 @@ sealed class RingDecodedEvent {
         override val kind = "history_measurement"
         override val confidence = DecodeConfidence.KNOWN
         override val debugJSON = "{}"
+    }
+
+    /**
+     * A CRP all-day "timing" vital-history frame just decoded (group 2, cmd 15/16/17/47). Carries no
+     * metric itself — its samples are emitted as [HistoryMeasurement]s — but signals the sync engine
+     * to pull the NEXT frame in the day's timeline, mirroring the vendor's sequential follow-up
+     * (`e1/{f,d,g,l}.java`: `insertBleMessage(<query>.b(day, index + 1))`). `cmd` identifies the vital,
+     * `frameIndex` the frame just received; the engine requests `frameIndex + 1` until the vital's
+     * terminal frame. Produces no `PulseEvent` (consumed by [CRPSyncEngine.handle]).
+     */
+    data class TimingHistoryFrame(
+        val cmd: Int,
+        val day: Int,
+        val frameIndex: Int,
+    ) : RingDecodedEvent() {
+        override val kind = "timing_history_frame"
+        override val confidence = DecodeConfidence.KNOWN
+        override val debugJSON = """{"cmd":$cmd,"day":$day,"frameIndex":$frameIndex}"""
     }
 
     /**

--- a/app/src/main/java/com/pulseloop/ring/RingEventBridge.kt
+++ b/app/src/main/java/com/pulseloop/ring/RingEventBridge.kt
@@ -106,6 +106,10 @@ object RingEventBridge {
         is RingDecodedEvent.WearingStatus ->
             listOf(PulseEvent.WearState(decoded.worn))
 
+        is RingDecodedEvent.TimingHistoryFrame ->
+            emptyList() // Drives CRPSyncEngine's next-frame follow-up; its samples arrive as
+                        // separate HistoryMeasurement events. Produces no PulseEvent itself.
+
         is RingDecodedEvent.MeasurementRejected ->
             emptyList() // A verdict on a command, not data — RingSyncCoordinator reads it off the
                         // raw-packet feed (SpotMeasurementGate) to fast-fail the named measurement

--- a/app/src/main/java/com/pulseloop/ring/RingEventBridge.kt
+++ b/app/src/main/java/com/pulseloop/ring/RingEventBridge.kt
@@ -104,7 +104,7 @@ object RingEventBridge {
             emptyList() // Diagnostic only
 
         is RingDecodedEvent.WearingStatus ->
-            emptyList() // Debug-feed only; nothing gates on wear state yet
+            listOf(PulseEvent.WearState(decoded.worn))
 
         is RingDecodedEvent.MeasurementRejected ->
             emptyList() // A verdict on a command, not data — RingSyncCoordinator reads it off the

--- a/app/src/main/java/com/pulseloop/service/EventPersistenceSubscriber.kt
+++ b/app/src/main/java/com/pulseloop/service/EventPersistenceSubscriber.kt
@@ -231,6 +231,7 @@ class EventPersistenceSubscriber(
             }
             is PulseEvent.HeartRateComplete -> {}
             is PulseEvent.Spo2Complete -> {}
+            is PulseEvent.WearState -> {} // Product orchestration only (fast-fail a measure); not persisted.
             is PulseEvent.RawPacket -> {
                 db.rawPacketDao().insert(RawPacketEntity(
                     directionRaw = event.direction.name,

--- a/app/src/main/java/com/pulseloop/service/RingSyncCoordinator.kt
+++ b/app/src/main/java/com/pulseloop/service/RingSyncCoordinator.kt
@@ -62,6 +62,12 @@ class RingSyncCoordinator(
         private set
     private var hrNoReadingReported = false
     private var spo2NoReadingReported = false
+    /** The ring told us it isn't on the finger during a spot measure (CRP wear-state push). Read by
+     *  the Vitals UI to show "put the ring on" instead of the generic steadiness hint. Set only when
+     *  the not-worn signal arrives *before* any reading, so a wear-state drop right after a good
+     *  reading (seen on real hardware, issue #29) can't turn a success into "not worn". */
+    var measureNotWorn: Boolean = false
+        private set
     /** The samples of the HR measurement in flight, and the rule for whether they settled — see
      *  [HRSampleWindow], which owns the warm-up echo and the consistency gate (iOS #66). */
     private val hrWindow = HRSampleWindow()
@@ -367,6 +373,7 @@ class RingSyncCoordinator(
         // Do NOT clear latestHRValue — it's the live value the workout UI shows, so a new
         // measurement keeps the last reading on screen until a fresh one replaces it.
         hrNoReadingReported = false
+        measureNotWorn = false
         hrWindow.begin()
 
         val spotToken = spot.begin(YCBTMeasurementMode.HEART_RATE)
@@ -407,6 +414,7 @@ class RingSyncCoordinator(
         spo2State = MeasureState.MEASURING
         latestSpO2Value = null
         spo2NoReadingReported = false
+        measureNotWorn = false
         val spotToken = spot.begin(YCBTMeasurementMode.SPO2)
         engine?.startSpO2()
         var result: Int? = null
@@ -476,6 +484,23 @@ class RingSyncCoordinator(
             is PulseEvent.Spo2Complete -> {
                 if (spo2State == MeasureState.MEASURING && latestSpO2Value == null) {
                     spo2NoReadingReported = true
+                }
+            }
+            // The CRP ring pushes wear state; `worn == false` means no skin contact, so an optical
+            // spot measure can't read (issue #29). Fast-fail the in-flight measure instead of idling
+            // out the full window, and flag *why* — but only if no reading landed first (a wear-state
+            // drop right after a good reading must not turn a success into a failure). Gated to CRP:
+            // other families' wear polarity is unverified (RingDecodedEvent.WearingStatus).
+            is PulseEvent.WearState -> {
+                if (!event.worn && client.state.value.activeDeviceType == RingDeviceType.CRP) {
+                    var flagged = false
+                    if (hrState == MeasureState.MEASURING && !measurementReceivedReading) {
+                        hrNoReadingReported = true; flagged = true
+                    }
+                    if (spo2State == MeasureState.MEASURING && latestSpO2Value == null) {
+                        spo2NoReadingReported = true; flagged = true
+                    }
+                    if (flagged) measureNotWorn = true
                 }
             }
             is PulseEvent.DeviceStateChanged -> {

--- a/app/src/main/java/com/pulseloop/ui/PulseLoopApp.kt
+++ b/app/src/main/java/com/pulseloop/ui/PulseLoopApp.kt
@@ -128,6 +128,24 @@ fun PulseLoopApp() {
             )
         }
 
+        // Guarantee sleep is repopulated after every sync. The CONNECTED handler wipes sleep_sessions
+        // to rebuild them from the ring (EventPersistenceSubscriber), but the full-sync SLEEP stage is
+        // gated behind four earlier watchdog-skippable stages and often doesn't re-deliver — so the
+        // Today tile / widgets can sit on "Sleep pending" until the user opens the Sleep screen, whose
+        // onOpen fires the reliable sleep-only fetch (syncSleepNow). Fire that same fetch here on the
+        // sync-completion edge — NOT on connect: syncSleepNow no-ops while a full sync is running
+        // (ColmiSyncEngine guards stage != IDLE/DONE), so it must run once the pipeline reaches DONE
+        // (syncProgress falls back to null). Its reply lands after the connect-clear, so it can't be
+        // wiped; the upsert is idempotent, so a sync whose SLEEP stage did survive just refreshes.
+        LaunchedEffect(Unit) {
+            var wasSyncing = false
+            coordinator.syncProgress.collect { progress ->
+                val syncing = progress != null
+                if (wasSyncing && !syncing) coordinator.syncSleepNow() // a full sync just finished
+                wasSyncing = syncing
+            }
+        }
+
         // ── Start services (one-shot on composition) ─────────────────────
         LaunchedEffect(Unit) {
             // Wire onConnected → run the startup/history sync only (matches iOS). Connecting

--- a/app/src/main/java/com/pulseloop/ui/screens/DebugScreen.kt
+++ b/app/src/main/java/com/pulseloop/ui/screens/DebugScreen.kt
@@ -249,6 +249,7 @@ private fun labelFor(event: PulseEvent): String = when (event) {
     is PulseEvent.HeartRateComplete -> "HR Done"
     is PulseEvent.Spo2Result -> "SpO₂"
     is PulseEvent.Spo2Complete -> "SpO₂ Done"
+    is PulseEvent.WearState -> if (event.worn) "Worn" else "Not Worn"
     is PulseEvent.HistoryMeasurement -> when (event.kind) {
         com.pulseloop.ring.MeasurementKind.HEART_RATE -> "HR History"
         com.pulseloop.ring.MeasurementKind.SPO2 -> "SpO₂ History"

--- a/app/src/main/java/com/pulseloop/ui/screens/Screens.kt
+++ b/app/src/main/java/com/pulseloop/ui/screens/Screens.kt
@@ -65,6 +65,9 @@ fun VitalsScreen(
     // the refusal gate keeps bad values off screen, and this surfaces the failure with iOS's
     // per-kind copy instead of silently re-enabling the button (second-pass finding #30).
     var measureFailed by remember { mutableStateOf(false) }
+    // Set alongside [measureFailed] when the CRP ring reported it wasn't on the finger, so the
+    // failure copy tells the user to put the ring on rather than the generic "hold still" (issue #29).
+    var measureNotWornHint by remember { mutableStateOf(false) }
     // Two measurement flavours:
     //  • combined (56ff/Jring): one 0x23 packet → BP + SpO₂ + stress + fatigue + blood sugar
     //  • spot (Colmi): sequential live HR + SpO₂ via the real-time command (0x69)
@@ -256,6 +259,7 @@ fun VitalsScreen(
                         onClick = {
                             measuring = true
                             measureFailed = false
+                            measureNotWornHint = false
                             remaining = measureSeconds
                             scope.launch {
                                 val ticker = launch {
@@ -272,6 +276,7 @@ fun VitalsScreen(
                                             coordinator.spo2State == com.pulseloop.service.RingSyncCoordinator.MeasureState.FAILED)
                                     ) {
                                         measureFailed = true
+                                        measureNotWornHint = coordinator.measureNotWorn
                                     }
                                     viewModel?.refreshNow()  // show the new reading immediately
                                 }
@@ -306,7 +311,10 @@ fun VitalsScreen(
                 // iOS MeasurementKindPresentation failure copy ("…Keep the ring snug and your
                 // hand still, then try again."), shown until the next attempt.
                 Text(
-                    "Couldn't get a steady reading. Keep the ring snug and your hand still, then try again.",
+                    if (measureNotWornHint)
+                        "The ring isn't detecting your finger. Put it on snugly, then try again."
+                    else
+                        "Couldn't get a steady reading. Keep the ring snug and your hand still, then try again.",
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.error,
                     modifier = Modifier.padding(top = 4.dp),

--- a/app/src/test/java/com/pulseloop/ring/CRPDecoderTest.kt
+++ b/app/src/test/java/com/pulseloop/ring/CRPDecoderTest.kt
@@ -240,6 +240,83 @@ class CRPDecoderTest {
         assertTrue(CRPDecoder.decode(frame, fdd3).none { it is RingDecodedEvent.SleepTimeline })
     }
 
+    // ── All-day "timing" vital history (group 2 / cmd 15/16/17/47, vendor e1/{f,d,g,l}) ──────────
+    // Frames captured verbatim from zaggash's Colmi R11 (rc2, issue #29): [day][frameIndex][slots…],
+    // one 5-minute slot per sample. HR/SpO2/stress = one byte/slot; HRV = little-endian 2 bytes/slot.
+
+    /** Real group-2/cmd-15 HR frame (day 0, frame 0): 19 non-zero 5-min slots, an overnight curve. */
+    private val hrTimingFrame =
+        "fdda1098020f000000003a000000000000003c000000004b0000000054000000005200000000680000000063000000005400" +
+        "0000006300000000006000000058000000004f00000000300000000063000000005a0000000060000000003f000000005c00" +
+        "0000005000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000" +
+        "0000"
+
+    /** Real group-2/cmd-16 HRV frame (day 0, frame 0): 11 non-zero slots, little-endian 2-byte values. */
+    private val hrvTimingFrame =
+        "fdda109802100000000000002f00000000000000000000000000000020000000000000000000000000000000000000003200" +
+        "0000000000000000000000000000000000001e00000000000000000021000000000000000000220000000000000000003300" +
+        "0000000000000000000021000000000000000000000000000000000024000000000000000000380000000000000000002400" +
+        "0000"
+
+    @Test
+    fun `HR timing frame decodes one bpm per 5-minute slot at the right time-of-day`() {
+        // day 0, so slots hang off local midnight; slot 2 → 00:10, slot 10 → 00:50, slot 95 → 07:55.
+        val now = Instant.parse("2026-07-24T12:00:00Z")
+        val events = CRPDecoder.decode(hexToBytes(hrTimingFrame), fdd3, now, ZoneId.of("UTC"))
+        val samples = events.filterIsInstance<RingDecodedEvent.HistoryMeasurement>()
+        assertEquals(19, samples.size)
+        assertTrue(samples.all { it.kind_field == MeasurementKind.HEART_RATE })
+        // First slot: 58 bpm at 00:10 (slot 2 × 5 min).
+        assertEquals(58.0, samples.first().value, 0.0)
+        assertEquals(Instant.parse("2026-07-24T00:10:00Z"), samples.first()._timestamp)
+        // A daytime peak the vendor keeps (within 40..200): 104 bpm at 02:30 (slot 30).
+        assertTrue(samples.any { it.value == 104.0 && it._timestamp == Instant.parse("2026-07-24T02:30:00Z") })
+        // Last slot: 80 bpm at 07:55 (slot 95).
+        assertEquals(80.0, samples.last().value, 0.0)
+        assertEquals(Instant.parse("2026-07-24T07:55:00Z"), samples.last()._timestamp)
+    }
+
+    @Test
+    fun `HRV timing frame decodes little-endian two-byte samples per slot`() {
+        val now = Instant.parse("2026-07-24T12:00:00Z")
+        val samples = CRPDecoder.decode(hexToBytes(hrvTimingFrame), fdd3, now, ZoneId.of("UTC"))
+            .filterIsInstance<RingDecodedEvent.HistoryMeasurement>()
+        assertEquals(11, samples.size)
+        assertTrue(samples.all { it.kind_field == MeasurementKind.HRV })
+        // First slot: 47 ms at 00:10 (slot 2, 2-byte value 0x002f).
+        assertEquals(47.0, samples.first().value, 0.0)
+        assertEquals(Instant.parse("2026-07-24T00:10:00Z"), samples.first()._timestamp)
+        // 2-byte cadence: HRV packs 72 slots/frame, so slot 10 is still 00:50.
+        assertTrue(samples.any { it.value == 32.0 && it._timestamp == Instant.parse("2026-07-24T00:50:00Z") })
+    }
+
+    @Test
+    fun `an all-zero timing frame yields no samples, only the follow-up marker`() {
+        // zaggash's SpO2 timeline came back all-zero (no all-day SpO2 recorded) — decode must not
+        // fabricate 0-valued samples, but must still emit the frame marker so the engine advances.
+        val frame = CRPProtocol.frame(CRPCommands.GROUP_HISTORY, CRPCommands.CMD_QUERY_TIMING_SPO2, ByteArray(146))
+        val events = CRPDecoder.decode(frame, fdd3)
+        assertTrue(events.none { it is RingDecodedEvent.HistoryMeasurement })
+        val marker = events.filterIsInstance<RingDecodedEvent.TimingHistoryFrame>().single()
+        assertEquals(CRPCommands.CMD_QUERY_TIMING_SPO2, marker.cmd)
+        assertEquals(0, marker.frameIndex)
+    }
+
+    @Test
+    fun `a timing frame emits a TimingHistoryFrame marker carrying its cmd, day and index`() {
+        val payload = byteArrayOf(1, 0) + ByteArray(144) // day 1, frame 0, empty slots
+        val frame = CRPProtocol.frame(CRPCommands.GROUP_HISTORY, CRPCommands.CMD_QUERY_TIMING_HR, payload)
+        val marker = CRPDecoder.decode(frame, fdd3).filterIsInstance<RingDecodedEvent.TimingHistoryFrame>().single()
+        assertEquals(CRPCommands.CMD_QUERY_TIMING_HR, marker.cmd)
+        assertEquals(1, marker.day)
+        assertEquals(0, marker.frameIndex)
+    }
+
+    @Test
+    fun `TimingHistoryFrame produces no PulseEvent`() {
+        assertTrue(RingEventBridge.eventsFor(RingDecodedEvent.TimingHistoryFrame(CRPCommands.CMD_QUERY_TIMING_HR, 0, 0)).isEmpty())
+    }
+
     private fun hexToBytes(hex: String): ByteArray =
         ByteArray(hex.length / 2) { ((hex[it * 2].digitToInt(16) shl 4) or hex[it * 2 + 1].digitToInt(16)).toByte() }
 }

--- a/app/src/test/java/com/pulseloop/ring/CRPDecoderTest.kt
+++ b/app/src/test/java/com/pulseloop/ring/CRPDecoderTest.kt
@@ -84,6 +84,33 @@ class CRPDecoderTest {
         assertTrue(CRPDecoder.decode(CRPProtocol.frame(1, CRPCommands.CMD_RESULT_TEMP, byteArrayOf(0x64, 0x00)), fdd3).isEmpty())
     }
 
+    // ---- Wear state: framed group-3 cmd-7 push (g1/a.java case 3->7, onWearStateChange). ----
+
+    @Test
+    fun `group3 cmd7 payload0 zero decodes wear state not worn`() {
+        // The exact frame from zaggash's build-25 captures (issue #29): ring off the finger.
+        val ev = CRPDecoder.decode(CRPProtocol.frame(3, CRPCommands.CMD_WEAR_STATE, byteArrayOf(0)), fdd3)[0]
+        assertFalse((ev as RingDecodedEvent.WearingStatus).worn)
+    }
+
+    @Test
+    fun `group3 cmd7 payload0 nonzero decodes wear state worn`() {
+        val ev = CRPDecoder.decode(CRPProtocol.frame(3, CRPCommands.CMD_WEAR_STATE, byteArrayOf(1)), fdd3)[0]
+        assertTrue((ev as RingDecodedEvent.WearingStatus).worn)
+    }
+
+    @Test
+    fun `wear state maps to a PulseEvent WearState`() {
+        val worn = RingEventBridge.eventsFor(RingDecodedEvent.WearingStatus(worn = false, _timestamp = Instant.EPOCH))
+        assertEquals(false, (worn.single() as PulseEvent.WearState).worn)
+    }
+
+    @Test
+    fun `unrecognised group3 cmd is acked, not dropped`() {
+        val ev = CRPDecoder.decode(CRPProtocol.frame(3, 2, byteArrayOf(0)), fdd3)[0]
+        assertTrue(ev is RingDecodedEvent.CommandAck)
+    }
+
     @Test
     fun `unrecognised group1 cmd is acked, not dropped`() {
         // cmd 0 (set-user-info ack) isn't a vital result -> CommandAck, no fabricated sample.

--- a/app/src/test/java/com/pulseloop/ring/CRPProtocolTest.kt
+++ b/app/src/test/java/com/pulseloop/ring/CRPProtocolTest.kt
@@ -86,6 +86,10 @@ class CRPProtocolTest {
         assertArrayEquals(byteArrayOf(0xFD.toByte(), 0xDA.toByte(), 0x10, 8, 2, 47, 0, 0), CRPProtocol.queryTimingStressHistory())
         // A non-today day flows into payload[0].
         assertArrayEquals(byteArrayOf(0xFD.toByte(), 0xDA.toByte(), 0x10, 8, 2, 15, 1, 0), CRPProtocol.queryTimingHeartRateHistory(1))
+        // The frame index (payload[1]) selects a later slice of the day's timeline for the follow-up
+        // pull — vendor `t.b(day, index)`; here today's frame 1 (00:00 stays day 0, index → 1).
+        assertArrayEquals(byteArrayOf(0xFD.toByte(), 0xDA.toByte(), 0x10, 8, 2, 15, 0, 1), CRPProtocol.queryTimingHeartRateHistory(0, 1))
+        assertArrayEquals(byteArrayOf(0xFD.toByte(), 0xDA.toByte(), 0x10, 8, 2, 16, 0, 2), CRPProtocol.queryTimingHrvHistory(0, 2))
     }
 
     @Test

--- a/app/src/test/java/com/pulseloop/ring/CRPProtocolTest.kt
+++ b/app/src/test/java/com/pulseloop/ring/CRPProtocolTest.kt
@@ -77,6 +77,18 @@ class CRPProtocolTest {
     }
 
     @Test
+    fun `all-day timing history queries match vendor group2 opcodes with day-zero payload`() {
+        // Vendor b1/{t,u,h,h0}.b(day, 0): group 2, cmds 15/16/17/47, payload [day, 0]; TODAY = 0.
+        // len = 6 header + 2 payload = 8. These are the queries the ring actually answers (issue #29).
+        assertArrayEquals(byteArrayOf(0xFD.toByte(), 0xDA.toByte(), 0x10, 8, 2, 15, 0, 0), CRPProtocol.queryTimingHeartRateHistory())
+        assertArrayEquals(byteArrayOf(0xFD.toByte(), 0xDA.toByte(), 0x10, 8, 2, 16, 0, 0), CRPProtocol.queryTimingHrvHistory())
+        assertArrayEquals(byteArrayOf(0xFD.toByte(), 0xDA.toByte(), 0x10, 8, 2, 17, 0, 0), CRPProtocol.queryTimingSpO2History())
+        assertArrayEquals(byteArrayOf(0xFD.toByte(), 0xDA.toByte(), 0x10, 8, 2, 47, 0, 0), CRPProtocol.queryTimingStressHistory())
+        // A non-today day flows into payload[0].
+        assertArrayEquals(byteArrayOf(0xFD.toByte(), 0xDA.toByte(), 0x10, 8, 2, 15, 1, 0), CRPProtocol.queryTimingHeartRateHistory(1))
+    }
+
+    @Test
     fun `spot measure toggles use the vendor opcodes hrv10 stress14 temp32`() {
         // b1/u.d, b1/h0.d, b1/i0.d — start(1)/stop(0) on group 1.
         assertArrayEquals(byteArrayOf(0xFD.toByte(), 0xDA.toByte(), 0x10, 7, 1, 10, 1), CRPProtocol.measureHRV(true))

--- a/app/src/test/java/com/pulseloop/ring/CRPSyncEngineTest.kt
+++ b/app/src/test/java/com/pulseloop/ring/CRPSyncEngineTest.kt
@@ -84,6 +84,51 @@ class CRPSyncEngineTest {
     }
 
     @Test
+    fun `a timing-history frame drives the next-frame pull until the vital's terminal frame`() {
+        val w = FakeWriter()
+        val engine = CRPSyncEngine(w)
+        // Clear the send buffer of the startup queries so we only see follow-ups.
+        engine.runStartup(); w.sent.clear()
+
+        // HR frame 0 → request HR frame 1 (its terminal frame); frame 1 → nothing further.
+        engine.handle(RingDecodedEvent.TimingHistoryFrame(CRPCommands.CMD_QUERY_TIMING_HR, day = 0, frameIndex = 0))
+        assertEquals(listOf(2 to 15), w.opcodes())
+        assertEquals(1, w.sent[0][7].toInt()) // payload[1] = requested frame index 1
+        w.sent.clear()
+        engine.handle(RingDecodedEvent.TimingHistoryFrame(CRPCommands.CMD_QUERY_TIMING_HR, day = 0, frameIndex = 1))
+        assertTrue("terminal HR frame must not request another", w.sent.isEmpty())
+    }
+
+    @Test
+    fun `HRV walks four frames, others two`() {
+        val w = FakeWriter()
+        val engine = CRPSyncEngine(w)
+        engine.runStartup(); w.sent.clear()
+        // HRV finalizes at frame 3: frames 0,1,2 each pull the next; frame 3 stops.
+        for (idx in 0..2) {
+            engine.handle(RingDecodedEvent.TimingHistoryFrame(CRPCommands.CMD_QUERY_TIMING_HRV, 0, idx))
+            assertEquals(idx + 1, w.sent.last()[7].toInt())
+        }
+        w.sent.clear()
+        engine.handle(RingDecodedEvent.TimingHistoryFrame(CRPCommands.CMD_QUERY_TIMING_HRV, 0, 3))
+        assertTrue(w.sent.isEmpty())
+    }
+
+    @Test
+    fun `a repeated frame does not spam duplicate follow-up requests`() {
+        val w = FakeWriter()
+        val engine = CRPSyncEngine(w)
+        engine.runStartup(); w.sent.clear()
+        // The ring re-sends HR frame 0 several times in one poll pass — only one frame-1 pull fires.
+        repeat(5) { engine.handle(RingDecodedEvent.TimingHistoryFrame(CRPCommands.CMD_QUERY_TIMING_HR, 0, 0)) }
+        assertEquals(1, w.sent.size)
+        // A fresh poll pass clears the guard, so the next sync re-pulls frame 1.
+        engine.runStartup(); w.sent.clear()
+        engine.handle(RingDecodedEvent.TimingHistoryFrame(CRPCommands.CMD_QUERY_TIMING_HR, 0, 0))
+        assertEquals(1, w.sent.size)
+    }
+
+    @Test
     fun `applyUserProfile pushes user info immediately`() {
         val w = FakeWriter()
         val engine = CRPSyncEngine(w)

--- a/app/src/test/java/com/pulseloop/ring/CRPSyncEngineTest.kt
+++ b/app/src/test/java/com/pulseloop/ring/CRPSyncEngineTest.kt
@@ -15,9 +15,10 @@ class CRPSyncEngineTest {
         fun opcodes(): List<Pair<Int, Int>> = sent.map { it[4].toInt() to it[5].toInt() }
     }
 
-    /** The all-day history pull appended to every runStartup (the poll pass). Group 7 for
-     *  HR/SpO2/HRV/stress, group 2 for temp/sleep — see CRPProtocol.queryHistory*. */
-    private val historyQueries = listOf(7 to 4, 7 to 7, 7 to 6, 7 to 5, 2 to 48, 2 to 14)
+    /** The all-day history pull appended to every runStartup (the poll pass). All group 2: the
+     *  "timing" vital timelines HR/SpO2/HRV/stress (cmd 15/17/16/47), then temp (48) + sleep (14) —
+     *  the opcodes the ring actually answers (issue #29). See CRPProtocol.queryTiming/queryHistory. */
+    private val historyQueries = listOf(2 to 15, 2 to 17, 2 to 16, 2 to 47, 2 to 48, 2 to 14)
 
     /** The all-day monitor enables sent on connect (default ALL_ON): HR, HRV, stress, SpO2, temp —
      *  see CRPSyncEngine.applyTimingSettings. Without these a fresh R11 records no history. */


### PR DESCRIPTION
## Context (issue #29)

The reported "HR Measure stopped working after all-day monitoring" turned out **not** to be a code regression. Comparing zaggash's captures (build 23 worn → HR returns; build 25 "broken" → nothing) surfaced `group 3 / cmd 7` frames present only in the failing capture, which the vendor `g1/a.java` decodes as `onWearStateChange(payload[0] > 0)` — the ring's **on-finger / skin-contact detection**. `payload[0] == 0` = ring not worn ⇒ the optical sensor can't read. A follow-up **worn** capture confirmed HR reads back ~17 s after the Measure press. The app simply never decoded wear state, so a not-worn measure spun the full window and failed silently.

## Wear-state fix (CRP-local)
- `CRPDecoder` decodes group-3/cmd-7 → `RingDecodedEvent.WearingStatus` (reusing the type YCBT already produces); `RingEventBridge` maps it to a new `PulseEvent.WearState`.
- `RingSyncCoordinator` fast-fails an in-flight CRP spot measure when the ring reports **not-worn before any reading** — mirroring the existing no-reading guards so a wear-state drop *right after* a good reading (observed on real hardware) can't turn a success into a failure — and flags `measureNotWorn` so the Vitals screen shows **"put the ring on"** instead of the generic steadiness hint.
- **Gated to CRP**: other families' wear polarity is unverified (`WearingStatus` confidence = PARTIAL).
- Net UX: a not-worn measure fails in ~2 s with guidance instead of spinning the full 30/60 s window silently.

## Diagnostics
- Raise the `rawPackets` export cap **200 → 1000**. High-frequency steps/activity pushes flooded the 200-frame buffer and evicted the command-channel frames a capture is actually taken for (the spot-measure round-trip, multi-frame history replies).
- Reminder for capturing protocol bytes: use the Debug screen's **"Export Full (Unmasked)"** — the default masked export blanks health-frame payloads (HR values, sleep stages).

## Also
- `versionCode` 25 → 26.
- `AGENTS.md`: document the wear-state finding + how to diagnose R11 from captures, and the standing vendor divergences to fix when tackling group-7 all-day history (query-state vs force-enable, `queryHistoryTimingHeartRate(day)` opcode, priority send path).

## Verification
- `TZ=UTC ./gradlew --no-daemon testDebugUnitTest --rerun-tasks` — green (adds 4 wear-state decode/bridge tests).
- `./gradlew --no-daemon :app:assembleDebug` — success.
- On-device confirmation (the "put the ring on" copy + fast-fail, and a clean SpO₂ read when worn) still needs a zaggash test build — not a blocker to merge the decode.