### PR TITLE
ci: move workflow actions off the deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,11 +19,16 @@ jobs:
         with:
           distribution: temurin
           java-version: '17'
-      # Deliberately v5, not the latest v6: v6 extracts caching into `gradle-actions-caching`,
-      # a proprietary component under Gradle's commercial Terms of Use rather than the MIT
-      # licence. v5 is the last MIT line and already runs on Node 24, which is all this bump
-      # needs. Read https://blog.gradle.org/github-actions-for-gradle-v6 before moving to v6.
-      - uses: gradle/actions/setup-gradle@v5
+      # `cache-provider: basic` is load-bearing, not a tuning knob. v6 moved the default caching
+      # implementation into `gradle-actions-caching`, a proprietary component governed by Gradle's
+      # commercial Terms of Use (https://blog.gradle.org/github-actions-for-gradle-v6); 'basic' is
+      # the open-source GitHub-Actions-cache implementation and keeps this repo off those terms.
+      # Don't drop this line to "take the default" — that silently opts into the commercial
+      # component. (v5 was the last fully-MIT line but is dead: v5.0.2, 2026-02, no security
+      # updates since.)
+      - uses: gradle/actions/setup-gradle@v6
+        with:
+          cache-provider: basic
       - name: Unit tests
         run: ./gradlew --no-daemon testDebugUnitTest
       - name: Build debug APK

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,18 +14,22 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '17'
-      - uses: gradle/actions/setup-gradle@v4
+      # Deliberately v5, not the latest v6: v6 extracts caching into `gradle-actions-caching`,
+      # a proprietary component under Gradle's commercial Terms of Use rather than the MIT
+      # licence. v5 is the last MIT line and already runs on Node 24, which is all this bump
+      # needs. Read https://blog.gradle.org/github-actions-for-gradle-v6 before moving to v6.
+      - uses: gradle/actions/setup-gradle@v5
       - name: Unit tests
         run: ./gradlew --no-daemon testDebugUnitTest
       - name: Build debug APK
         run: ./gradlew --no-daemon :app:assembleDebug
       - name: Upload test APK
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pulseloop-debug-apk
           path: app/build/outputs/apk/debug/*.apk

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Parse version from tag
         id: ver
@@ -39,12 +39,15 @@ jobs:
           echo "prerelease=$PRERELEASE" >> "$GITHUB_OUTPUT"
           echo "Building versionName=$NAME versionCode=$CODE prerelease=$PRERELEASE"
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '17'
 
-      - uses: gradle/actions/setup-gradle@v4
+      # Deliberately v5, not the latest v6 — see the note in ci.yml: v6's caching moved to a
+      # proprietary component under Gradle's commercial Terms of Use. v5 is the last MIT line
+      # and already runs on Node 24.
+      - uses: gradle/actions/setup-gradle@v5
 
       - name: Decode release keystore
         env:
@@ -93,7 +96,7 @@ jobs:
           ls -la dist
 
       - name: Create / update release and attach APKs
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ github.ref_name }}
           name: PulseLoop ${{ steps.ver.outputs.name }} (${{ steps.ver.outputs.code }})

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,10 +44,11 @@ jobs:
           distribution: temurin
           java-version: '17'
 
-      # Deliberately v5, not the latest v6 — see the note in ci.yml: v6's caching moved to a
-      # proprietary component under Gradle's commercial Terms of Use. v5 is the last MIT line
-      # and already runs on Node 24.
-      - uses: gradle/actions/setup-gradle@v5
+      # cache-provider: basic — see the note in ci.yml. Keeps caching on the open-source
+      # implementation rather than v6's default commercial `gradle-actions-caching`.
+      - uses: gradle/actions/setup-gradle@v6
+        with:
+          cache-provider: basic
 
       - name: Decode release keystore
         env:


### PR DESCRIPTION
The `v2.5.0+35` release run warned that four actions target Node 20 and are being force-run on Node 24, and that `setup-java` v4 is EOL. Builds pass today; this closes it out before the forced-migration window does.

| Action | From | To |
|---|---|---|
| `actions/checkout` | v4 | **v7** |
| `actions/setup-java` | v4 | **v5** |
| `gradle/actions/setup-gradle` | v4 | **v6** + `cache-provider: basic` |
| `actions/upload-artifact` | v4 | **v7** |
| `softprops/action-gh-release` | v2 | **v3** |

Every one of these majors is a Node 20 → 24 runtime bump. I read the release notes for each; **none changes an input this repo passes.** Specifically:

- **checkout v7** also blocks fork checkouts for `pull_request_target` and `workflow_run` — neither workflow uses those events (CI is on `pull_request`).
- **upload-artifact v7** adds an optional `archive` input and leaves `name` / `path` / `if-no-files-found` / `retention-days` untouched.
- All require runner ≥ 2.327.1; GitHub-hosted `ubuntu-latest` is well past that.

## setup-gradle: v6 with `cache-provider: basic`

v6 moved the **default** caching implementation into `gradle-actions-caching`, a proprietary component governed by [Gradle's commercial Terms of Use](https://blog.gradle.org/github-actions-for-gradle-v6). An earlier revision of this PR stopped at v5 to avoid that. Two things make v6 the better call:

1. **v5 is a dead line.** Last release `v5.0.2` (2026-02-23); `v6.0.0` landed a month later and there has been nothing on v5 since. v6.0.0's notes cite dependency updates for security vulnerabilities — so pinning v5 would fix the Node 20 deprecation by parking on a branch that gets no security updates.
2. **v6 has an open-source caching mode**, so the licensing concern implied a choice that doesn't actually exist. `cache-provider` selects between `enhanced` (default, the commercial component) and `basic` (the open-source GitHub Actions cache implementation).

`cache-provider: basic` therefore gets Node 24, an actively maintained line, security updates *and* caching, without accepting those terms:

| | v5 | v6 default | **v6 + `basic`** |
|---|---|---|---|
| Node 24 | ✅ | ✅ | ✅ |
| Security updates | ❌ dead | ✅ | ✅ |
| Caching | ✅ MIT | ✅ commercial | ✅ **open source** |
| Commercial terms | none | accepted | **none** |

Both workflows set the input explicitly **and comment why**, because the failure mode is silent: deleting the line doesn't break the build, it just opts into the commercial component on the next run.

v6 also drops the rudimentary configuration-cache support pending a reimplementation. These workflows run `--no-daemon` and never enabled the configuration cache, so that costs nothing here.

> Note `cache-provider` exists as of v6.3.0, so this relies on the floating `@v6` tag staying at 6.3.0+ — consistent with how this repo pins every other action. Pin `@v6.3.0` exactly if you'd rather not depend on that.

## Verification

Workflow YAML parses cleanly with the expected structure (ci: 1 job / 6 steps; release: 1 job / 8 steps). The real check is CI on this PR.

**Caveat: this PR exercises `ci.yml` only.** `release.yml` runs on tag pushes, so its changes stay unverified until the next release tag — worth knowing if the next release is time-sensitive. The changes are identical in kind to the ones CI does cover.
